### PR TITLE
Fix WiFi reconnect failing

### DIFF
--- a/src/kernel/Concurrent.hpp
+++ b/src/kernel/Concurrent.hpp
@@ -84,12 +84,24 @@ public:
         return count;
     }
 
+    void take() {
+        take([](const TMessage& message) {});
+    }
+
     void take(MessageHandler handler) {
         while (!pollIn(ticks::max(), handler)) { }
     }
 
+    bool poll() {
+        return poll([](const TMessage& message) {});
+    }
+
     bool poll(MessageHandler handler) {
         return pollIn(ticks::zero(), handler);
+    }
+
+    bool pollIn(ticks timeout) {
+        return pollIn(timeout, [](const TMessage& message) {});
     }
 
     bool pollIn(ticks timeout, MessageHandler handler) {
@@ -100,6 +112,10 @@ public:
         handler(*message);
         delete message;
         return true;
+    }
+
+    void clear() {
+        xQueueReset(queue);
     }
 
 private:

--- a/src/kernel/Task.hpp
+++ b/src/kernel/Task.hpp
@@ -24,13 +24,13 @@ typedef std::function<void(Task&)> TaskFunction;
 
 class Task {
 public:
-    static void inline run(const String& name, TaskFunction runFunction) {
+    static void inline run(const String& name, const TaskFunction runFunction) {
         Task::run(name, DEFAULT_STACK_SIZE, DEFAULT_PRIORITY, runFunction);
     }
-    static void inline run(const String& name, uint32_t stackSize, TaskFunction runFunction) {
+    static void inline run(const String& name, uint32_t stackSize, const TaskFunction runFunction) {
         Task::run(name, stackSize, DEFAULT_PRIORITY, runFunction);
     }
-    static void run(const String& name, uint32_t stackSize, UBaseType_t priority, TaskFunction runFunction) {
+    static void run(const String& name, uint32_t stackSize, UBaseType_t priority, const TaskFunction runFunction) {
         Task* task = new Task(String(name), runFunction);
         Serial.println("Creating task " + String(name) + " with priority " + String(priority) + " and stack size " + String(stackSize));
         xTaskCreate(executeTask, name.c_str(), stackSize, task, priority, &(task->taskHandle));
@@ -93,8 +93,8 @@ private:
         vTaskDelete(handle);
     }
 
-    String name;
-    TaskFunction taskFunction;
+    const String name;
+    const TaskFunction taskFunction;
     TaskHandle_t taskHandle;
     TickType_t lastWakeTime;
 };

--- a/src/kernel/drivers/WiFiDriver.hpp
+++ b/src/kernel/drivers/WiFiDriver.hpp
@@ -6,8 +6,11 @@
 
 #include <WiFiManager.h>
 
+#include <kernel/Concurrent.hpp>
 #include <kernel/State.hpp>
 #include <kernel/Task.hpp>
+
+using namespace farmhub::kernel;
 
 namespace farmhub { namespace kernel { namespace drivers {
 
@@ -33,10 +36,11 @@ public:
             },
             ARDUINO_EVENT_WIFI_STA_CONNECTED);
         WiFi.onEvent(
-            [&networkReady](WiFiEvent_t event, WiFiEventInfo_t info) {
+            [this, &networkReady](WiFiEvent_t event, WiFiEventInfo_t info) {
                 Serial.println("WiFi: got IP " + IPAddress(info.got_ip.ip_info.ip.addr).toString()
                     + ", netmask: " + IPAddress(info.got_ip.ip_info.netmask.addr).toString()
                     + ", gateway: " + IPAddress(info.got_ip.ip_info.gw.addr).toString());
+                reconnectQueue.clear();
                 networkReady.setFromISR();
             },
             ARDUINO_EVENT_WIFI_STA_GOT_IP);
@@ -45,7 +49,7 @@ public:
                 Serial.println("WiFi: lost IP address");
                 // TODO What should we do here?
                 networkReady.clearFromISR();
-                requestReconnect();
+                reconnectQueue.overwriteFromISR(true);
             },
             ARDUINO_EVENT_WIFI_STA_LOST_IP);
         WiFi.onEvent(
@@ -53,34 +57,29 @@ public:
                 Serial.println("WiFi: disconnected from " + String(info.wifi_sta_disconnected.ssid, info.wifi_sta_disconnected.ssid_len)
                     + ", reason: " + String(WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason))));
                 networkReady.clearFromISR();
-                requestReconnect();
+                reconnectQueue.overwriteFromISR(true);
             },
             ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
 
         Task::run("WiFi", 3072, [this, &networkReady, hostname](Task& task) {
+            millis();
             while (true) {
-                bool connected = wifiManager.autoConnect(hostname.c_str());
-                // TODO Wait truly indefinitely when we are connected, not 49.7 days
-                ticks timeout = connected
-                    ? ticks::max()
-                    : ticks::zero();
-                xSemaphoreTake(reconnectSemaphor, timeout.count());
+                bool connected = WiFi.isConnected() || wifiManager.autoConnect(hostname.c_str());
+                if (connected) {
+                    reconnectQueue.take();
+                } else {
+                    reconnectQueue.clear();
+                }
+                // TODO Add exponential backoff
+                task.delay(seconds(5));
                 Serial.println("WiFi: Reconnecting...");
-                // TODO Does this fix "wifi: addba response cb: ap bss deleted"?
-                // WiFi.disconnect(true);
             }
         });
     }
 
 private:
-    void requestReconnect() {
-        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-        xSemaphoreGiveFromISR(reconnectSemaphor, &xHigherPriorityTaskWoken);
-        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-    }
-
     WiFiManager wifiManager;
-    QueueHandle_t reconnectSemaphor = xSemaphoreCreateBinary();
+    Queue<bool> reconnectQueue { "wifi-reconnect", 1 };
 };
 
 }}}    // namespace farmhub::kernel::drivers

--- a/src/kernel/drivers/WiFiDriver.hpp
+++ b/src/kernel/drivers/WiFiDriver.hpp
@@ -50,7 +50,8 @@ public:
             ARDUINO_EVENT_WIFI_STA_LOST_IP);
         WiFi.onEvent(
             [this, &networkReady](WiFiEvent_t event, WiFiEventInfo_t info) {
-                Serial.println("WiFi: disconnected from " + String(info.wifi_sta_disconnected.ssid, info.wifi_sta_disconnected.ssid_len));
+                Serial.println("WiFi: disconnected from " + String(info.wifi_sta_disconnected.ssid, info.wifi_sta_disconnected.ssid_len)
+                    + ", reason: " + String(WiFi.disconnectReasonName(static_cast<wifi_err_reason_t>(info.wifi_sta_disconnected.reason))));
                 networkReady.clearFromISR();
                 requestReconnect();
             },
@@ -65,6 +66,8 @@ public:
                     : ticks::zero();
                 xSemaphoreTake(reconnectSemaphor, timeout.count());
                 Serial.println("WiFi: Reconnecting...");
+                // TODO Does this fix "wifi: addba response cb: ap bss deleted"?
+                // WiFi.disconnect(true);
             }
         });
     }


### PR DESCRIPTION
Often the device would get locked into an infinite loop of WiFi reconnect on boot. It seems that this was caused by an `WIFI_REASON_ASSOC_LEAVE` sometimes being sent by the router, which in turn caused a request to reconnect happen, which in turn would immediately force WiFi to try to reconnect in a loop.

Now we are much more robust in checking if we are actually connected, and we also wait a bit before attempting a reconnect, to avoid flooding the AP.