### PR TITLE
Improve stability of WiFi connection on first boot on MK6

### DIFF
--- a/src/kernel/drivers/WiFiDriver.hpp
+++ b/src/kernel/drivers/WiFiDriver.hpp
@@ -18,8 +18,6 @@ namespace farmhub::kernel::drivers {
 class WiFiDriver {
 public:
     WiFiDriver(StateSource& networkReady, StateSource& configPortalRunning, const String& hostname) {
-        WiFi.mode(WIFI_STA);
-        WiFi.setHostname(hostname.c_str());
         wifiManager.setHostname(hostname.c_str());
         wifiManager.setConfigPortalTimeout(180);
         wifiManager.setAPCallback([this, &configPortalRunning](WiFiManager* wifiManager) {


### PR DESCRIPTION
Looks like manually setting `WiFi.mode()` made MK6 devices a lot less stable to connect initially. Let's trust WiFiManager to handle WiFi on its own. This seems to fix the problem.