### PR TITLE
Do not explicitly wake up motor drivers at boot

### DIFF
--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -228,14 +228,6 @@ public:
         mqttDeviceRoot->registerCommand(fileRemoveCommand);
         mqttDeviceRoot->registerCommand(httpUpdateCommand);
 
-#if defined(MK4)
-        deviceDefinition.motorDriver.wakeUp();
-#elif defined(MK5)
-        deviceDefinition.motorADriver.wakeUp();
-#elif defined(MK6)
-        deviceDefinition.motorDriver.wakeUp();
-#endif
-
         // We want RTC to be in sync before we start setting up peripherals
         kernel.getRtcInSyncState().awaitSet();
 

--- a/src/devices/Peripheral.hpp
+++ b/src/devices/Peripheral.hpp
@@ -162,7 +162,7 @@ public:
     }
 
     void createPeripheral(const String& peripheralConfig) {
-        Log.info("Creating peripheral with config: %s",
+        Log.infoln("Creating peripheral with config: %s",
             peripheralConfig.c_str());
         PeripheralDeviceConfiguration deviceConfig;
         try {

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -362,7 +362,7 @@ private:
             topic.c_str(), qos);
         bool success = mqttClient.subscribe(topic.c_str(), static_cast<int>(qos));
         if (!success) {
-            Log.error("MQTT: Error subscribing to topic '%s', error = %d\n",
+            Log.errorln("MQTT: Error subscribing to topic '%s', error = %d\n",
                 topic.c_str(), mqttClient.lastError());
         }
         return success;


### PR DESCRIPTION
We don't need this for the drivers to operate, but it causes weird lights on the MK4 to show up.