### PR TITLE
Fix non-latching valve drivers

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/kernel/drivers/Drv8801Driver.hpp
+++ b/src/kernel/drivers/Drv8801Driver.hpp
@@ -61,9 +61,11 @@ public:
     void drive(MotorPhase phase, double duty = 1) override {
         if (duty == 0) {
             Log.traceln("Stopping");
+            sleep();
             digitalWrite(enablePin, LOW);
             return;
         }
+        wakeUp();
         digitalWrite(enablePin, HIGH);
 
         int direction = (phase == MotorPhase::FORWARD ? 1 : -1);

--- a/src/peripherals/valve/ValveComponent.hpp
+++ b/src/peripherals/valve/ValveComponent.hpp
@@ -54,21 +54,26 @@ protected:
     void driveAndHold(PwmMotorDriver& controller, ValveState targetState) {
         switch (targetState) {
             case ValveState::OPEN:
-                controller.drive(MotorPhase::FORWARD, holdDuty);
+                driveAndHold(controller, MotorPhase::FORWARD);
                 break;
             case ValveState::CLOSED:
-                controller.drive(MotorPhase::REVERSE, holdDuty);
+                driveAndHold(controller, MotorPhase::REVERSE);
                 break;
             default:
                 // Ignore
                 break;
         }
-        delay(switchDuration.count());
-        controller.stop();
     }
 
     const milliseconds switchDuration;
     const double holdDuty;
+
+private:
+    void driveAndHold(PwmMotorDriver& controller, MotorPhase phase) {
+        controller.drive(phase, 1.0);
+        delay(switchDuration.count());
+        controller.drive(phase, holdDuty);
+    }
 };
 
 class NormallyClosedValveControlStrategy


### PR DESCRIPTION
As with the normally-closed solenoids used on the MK4, we had some bug that caused these not to open properly. Now the strategies are fixed, and the MK4 DRV8801 driver handles its job well.