### PR TITLE
Fix hanging MQTT incoming queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,11 +76,3 @@ jobs:
               with:
                   files: firmware-*/*
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    ready-to-merge:
-        needs: build
-        if: ${{ github.ref != 'refs/heads/main' }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Dummy
-              run: echo "Everything is green across the board on ${{ github.ref }}"

--- a/src/devices/Peripheral.hpp
+++ b/src/devices/Peripheral.hpp
@@ -47,7 +47,6 @@ public:
             Log.verboseln("No telemetry to publish for peripheral: %s", name.c_str());
             return;
         }
-        // TODO Add device ID
         mqttRoot->publish("telemetry", telemetryDoc);
     }
 

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <list>
 #include <memory>
 
@@ -75,7 +76,7 @@ public:
             String suffix = "commands/" + name;
             return subscribe(suffix, QoS::ExactlyOnce, [this, name, suffix, responseSize, handler](const String&, const JsonObject& request) {
                 // Clear topic and wait for it to be cleared
-                mqtt.clear(fullTopic(suffix), Retention::Retain, QoS::ExactlyOnce, xTaskGetCurrentTaskHandle(), ticks::max());
+                mqtt.clear(fullTopic(suffix), Retention::Retain, QoS::ExactlyOnce, xTaskGetCurrentTaskHandle(), std::chrono::seconds { 5 });
 
                 DynamicJsonDocument responseDoc(responseSize);
                 auto response = responseDoc.to<JsonObject>();


### PR DESCRIPTION
Do not wait indefinitely for command clear to finish, thus a single network error cannot cause the whole command system to become unavailable.