### PR TITLE
Fix flow-control for MK5

### DIFF
--- a/data-templates/flow-control-mk5.json
+++ b/data-templates/flow-control-mk5.json
@@ -9,7 +9,7 @@
           "motor": "a"
         },
         "flow-meter": {
-          "pin": 6
+          "pin": 5
         }
       }
     }

--- a/src/kernel/drivers/Drv8874Driver.hpp
+++ b/src/kernel/drivers/Drv8874Driver.hpp
@@ -50,6 +50,13 @@ public:
     }
 
     void drive(MotorPhase phase, double duty = 1) override {
+        if (duty == 0) {
+            Log.traceln("Stopping motor");
+            sleep();
+            return;
+        }
+        wakeUp();
+
         int dutyValue = in1Channel.maxValue() / 2 + (int) (in1Channel.maxValue() / 2 * duty);
         Log.traceln("Driving motor %s at %d%%",
             phase == MotorPhase::FORWARD ? "forward" : "reverse",


### PR DESCRIPTION
It used the wrong flow meter pin and slept badly.