### PR TITLE
Allow devices to configure a secure MQTT connection

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ monitor_speed = 115200
 
 lib_deps =
     ${base.lib_deps}
-    256dpi/MQTT@^2.5.2
+    hideakitai/MQTTPubSubClient@^0.3.2
     https://github.com/tzapu/WiFiManager.git#v2.0.16-rc.2
     arduino-libraries/NTPClient@^3.2.1
     thijse/ArduinoLog@^1.1.1

--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -269,7 +269,7 @@ public:
                 json["wakeup"] = esp_sleep_get_wakeup_cause();
                 json["bootCount"] = bootCount++;
                 json["time"] = time(nullptr);
-            });
+            }, MqttDriver::Retention::NoRetain, MqttDriver::QoS::AtLeastOnce, milliseconds::zero(), 8192);
         Task::loop("telemetry", 8192, [this](Task& task) {
             publishTelemetry();
             // TODO Configure telemetry heartbeat interval

--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -283,12 +283,20 @@ private:
         peripheralManager.publishTelemetry();
     }
 
+    String locationPrefix() {
+        if (deviceConfig.location.hasValue()) {
+            return deviceConfig.location.get() + "/";
+        } else {
+            return "";
+        }
+    }
+
     ConfiguredKernel configuredKernel;
     Kernel<TDeviceConfiguration>& kernel = configuredKernel.kernel;
     TDeviceDefinition& deviceDefinition = configuredKernel.deviceDefinition;
     TDeviceConfiguration& deviceConfig = deviceDefinition.config;
 
-    shared_ptr<MqttDriver::MqttRoot> mqttDeviceRoot = kernel.mqtt.forRoot("devices/ugly-duckling/" + deviceConfig.instance.get());
+    shared_ptr<MqttDriver::MqttRoot> mqttDeviceRoot = kernel.mqtt.forRoot(locationPrefix() + "devices/ugly-duckling/" + deviceConfig.instance.get());
     PeripheralManager peripheralManager { mqttDeviceRoot };
 
     TelemetryCollector deviceTelemetryCollector;

--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -202,7 +202,7 @@ private:
 class ConfiguredKernel : ConsoleProvider {
 public:
     TDeviceDefinition deviceDefinition;
-    Kernel<TDeviceConfiguration> kernel { deviceDefinition.config, deviceDefinition.statusLed };
+    Kernel<TDeviceConfiguration> kernel { deviceDefinition.config, deviceDefinition.mqttConfig, deviceDefinition.statusLed };
 };
 
 class Device {

--- a/src/devices/DeviceDefinition.hpp
+++ b/src/devices/DeviceDefinition.hpp
@@ -34,7 +34,6 @@ public:
     Property<String> instance;
     Property<String> location { this, "location" };
 
-    NamedConfigurationEntry<MqttDriver::Config> mqtt { this, "mqtt" };
     NamedConfigurationEntry<RtcDriver::Config> ntp { this, "ntp" };
 
     ArrayProperty<JsonAsString> peripherals { this, "peripherals" };
@@ -81,9 +80,11 @@ public:
 
 private:
     ConfigurationFile<TDeviceConfiguration> configFile { FileSystem::get(), "/device-config.json" };
+    ConfigurationFile<MqttDriver::Config> mqttConfigFile { FileSystem::get(), "/mqtt-config.json" };
 
 public:
     TDeviceConfiguration& config = configFile.config;
+    MqttDriver::Config& mqttConfig = mqttConfigFile.config;
 
 private:
     I2CEnvironmentFactory<Sht31Component> sht3xFactory { "sht3x", 0x44 /* Also supports 0x45 */ };

--- a/src/devices/DeviceDefinition.hpp
+++ b/src/devices/DeviceDefinition.hpp
@@ -32,6 +32,7 @@ public:
 
     Property<String> model;
     Property<String> instance;
+    Property<String> location { this, "location" };
 
     NamedConfigurationEntry<MqttDriver::Config> mqtt { this, "mqtt" };
     NamedConfigurationEntry<RtcDriver::Config> ntp { this, "ntp" };

--- a/src/kernel/Kernel.hpp
+++ b/src/kernel/Kernel.hpp
@@ -54,9 +54,10 @@ static const String& getMacAddress() {
 template <typename TDeviceConfiguration>
 class Kernel {
 public:
-    Kernel(TDeviceConfiguration& deviceConfig, LedDriver& statusLed)
+    Kernel(TDeviceConfiguration& deviceConfig, MqttDriver::Config& mqttConfig, LedDriver& statusLed)
         : version(VERSION)
         , deviceConfig(deviceConfig)
+        , mqttConfig(mqttConfig)
         , statusLed(statusLed) {
 
         Log.infoln("Initializing FarmHub kernel version %s on %s instance '%s' with hostname '%s'",
@@ -226,6 +227,7 @@ private:
     }
 
     TDeviceConfiguration& deviceConfig;
+    MqttDriver::Config& mqttConfig;
 
     LedDriver& statusLed;
     KernelState state = KernelState::BOOTING;
@@ -253,7 +255,7 @@ private:
     String httpUpdateResult;
 
 public:
-    MqttDriver mqtt { networkReadyState, mdns, deviceConfig.mqtt.get(), deviceConfig.instance.get(), mqttReadyState };
+    MqttDriver mqtt { networkReadyState, mdns, mqttConfig, deviceConfig.instance.get(), mqttReadyState };
 };
 
 }    // namespace farmhub::kernel

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -184,7 +184,7 @@ public:
         Property<String> host { this, "host", "" };
         Property<unsigned int> port { this, "port", 1883 };
         Property<String> clientId { this, "clientId", "" };
-        Property<String> topic { this, "topic", "" };
+        Property<String> location { this, "location", "" };
         Property<size_t> queueSize { this, "queueSize", 16 };
         ArrayProperty<String> serverCert { this, "serverCert" };
         ArrayProperty<String> clientCert { this, "clientCert" };
@@ -213,7 +213,9 @@ public:
     }
 
     shared_ptr<MqttRoot> forRoot(const String& topic) {
-        return make_shared<MqttRoot>(*this, topic);
+        const String& location = config.location.get();
+        String localizedTopic = location.isEmpty() ? topic : location + "/" + topic;
+        return make_shared<MqttRoot>(*this, localizedTopic);
     }
 
 private:

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -184,7 +184,6 @@ public:
         Property<String> host { this, "host", "" };
         Property<unsigned int> port { this, "port", 1883 };
         Property<String> clientId { this, "clientId", "" };
-        Property<String> location { this, "location", "" };
         Property<size_t> queueSize { this, "queueSize", 16 };
         ArrayProperty<String> serverCert { this, "serverCert" };
         ArrayProperty<String> clientCert { this, "clientCert" };
@@ -213,9 +212,7 @@ public:
     }
 
     shared_ptr<MqttRoot> forRoot(const String& topic) {
-        const String& location = config.location.get();
-        String localizedTopic = location.isEmpty() ? topic : location + "/" + topic;
-        return make_shared<MqttRoot>(*this, localizedTopic);
+        return make_shared<MqttRoot>(*this, topic);
     }
 
 private:

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -199,7 +199,6 @@ public:
         : networkReady(networkReady)
         , mdns(mdns)
         , config(config)
-        , instanceName(instanceName)
         , clientId(getClientId(config.clientId.get(), instanceName))
         , mqttReady(mqttReady) {
         Task::run("mqtt:init", 4096, [this](Task& task) {
@@ -428,7 +427,6 @@ private:
     MdnsDriver& mdns;
     bool trustMdnsCache = true;
     const Config& config;
-    const String instanceName;
 
     const String clientId;
 


### PR DESCRIPTION
Moved MQTT configuration to `mqtt-config.json` where the server and client certs can be specified, like so:

```jsonc
{
  "host": "motherhen.kertkaland.com",
  "port": 8883,
  "serverCert": [
    "-----BEGIN CERTIFICATE-----",
    // ...
    "-----END CERTIFICATE-----"
  ],
  "clientCert": [
    "-----BEGIN CERTIFICATE-----",
    // ...
    "-----END CERTIFICATE-----"
  ],
  "clientKey": [
    "-----BEGIN RSA PRIVATE KEY-----",
    // ...
    "-----END RSA PRIVATE KEY-----"
  ]
}
```

There is now also a `location` property in `device-config.json`, as devices connecting directly to the server need to specify where they are:

```jsonc
{
  "instance": "test-mk6-2",
  "location": "test-zone",
  "peripherals": [
    // ...
  ]
}
```