### PR TITLE
Add support for soil moisture sensor

### DIFF
--- a/src/devices/DeviceDefinition.hpp
+++ b/src/devices/DeviceDefinition.hpp
@@ -15,6 +15,7 @@
 #include <peripherals/environment/Sht2xComponent.hpp>
 #include <peripherals/environment/Sht31Component.hpp>
 #include <peripherals/environment/Ds18B20SoilSensor.hpp>
+#include <peripherals/environment/SoilMoistureSensor.hpp>
 
 #include <version.h>
 
@@ -65,6 +66,7 @@ public:
         peripheralManager.registerFactory(sht2xFactory);
         peripheralManager.registerFactory(htu2xFactory);
         peripheralManager.registerFactory(ds18b20SoilSensorFactory);
+        peripheralManager.registerFactory(soilMoistureSensorFactory);
         registerDeviceSpecificPeripheralFactories(peripheralManager);
     }
 
@@ -94,6 +96,7 @@ private:
     I2CEnvironmentFactory<Sht31Component> sht3xFactory { "sht3x", 0x44 /* Also supports 0x45 */ };
     I2CEnvironmentFactory<Sht2xComponent<SHT2x>> sht2xFactory { "sht2x", 0x40 /* Not configurable */ };
     I2CEnvironmentFactory<Sht2xComponent<HTU21>> htu2xFactory { "htu2x", 0x40 /* Not configurable */ };
+    SoilMoistureSensorFactory soilMoistureSensorFactory;
 
     Ds18B20SoilSensorFactory ds18b20SoilSensorFactory;
 };

--- a/src/peripherals/I2CConfig.hpp
+++ b/src/peripherals/I2CConfig.hpp
@@ -9,7 +9,7 @@
 using namespace std::chrono;
 using namespace farmhub::kernel;
 
-namespace farmhub::peripherals::environment {
+namespace farmhub::peripherals {
 
 struct I2CConfig {
 public:

--- a/src/peripherals/SinglePinDeviceConfig.hpp
+++ b/src/peripherals/SinglePinDeviceConfig.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <chrono>
+
+#include <Arduino.h>
+
+#include <kernel/Configuration.hpp>
+
+using namespace std::chrono;
+using namespace farmhub::kernel;
+
+namespace farmhub::peripherals {
+
+class SinglePinDeviceConfig
+    : public ConfigurationSection {
+public:
+    Property<gpio_num_t> pin { this, "pin", GPIO_NUM_NC };
+};
+
+}    // namespace farmhub::peripherals::environment

--- a/src/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/src/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -5,21 +5,17 @@
 #include <devices/Peripheral.hpp>
 #include <kernel/Configuration.hpp>
 #include <kernel/drivers/MqttDriver.hpp>
+#include <peripherals/SinglePinDeviceConfig.hpp>
 
 #include "Ds18B20SoilSensorComponent.hpp"
 
 using namespace farmhub::devices;
 using namespace farmhub::kernel;
 using namespace farmhub::kernel::drivers;
+using namespace farmhub::peripherals;
 using std::make_unique;
 using std::unique_ptr;
 namespace farmhub::peripherals::environment {
-
-class Ds18B20SoilSensorDeviceConfig
-    : public ConfigurationSection {
-public:
-    Property<gpio_num_t> pin { this, "pin", GPIO_NUM_NC };
-};
 
 class Ds18B20SoilSensor
     : public Peripheral<EmptyConfiguration> {
@@ -38,13 +34,13 @@ private:
 };
 
 class Ds18B20SoilSensorFactory
-    : public PeripheralFactory<Ds18B20SoilSensorDeviceConfig, EmptyConfiguration> {
+    : public PeripheralFactory<SinglePinDeviceConfig, EmptyConfiguration> {
 public:
     Ds18B20SoilSensorFactory()
-        : PeripheralFactory<Ds18B20SoilSensorDeviceConfig, EmptyConfiguration>("environment:ds18b20") {
+        : PeripheralFactory<SinglePinDeviceConfig, EmptyConfiguration>("environment:ds18b20") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const String& name, const Ds18B20SoilSensorDeviceConfig& deviceConfig, shared_ptr<MqttDriver::MqttRoot> mqttRoot) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const String& name, const SinglePinDeviceConfig& deviceConfig, shared_ptr<MqttDriver::MqttRoot> mqttRoot) override {
         return make_unique<Ds18B20SoilSensor>(name, mqttRoot, deviceConfig.pin.get());
     }
 };

--- a/src/peripherals/environment/Ds18B20SoilSensorComponent.hpp
+++ b/src/peripherals/environment/Ds18B20SoilSensorComponent.hpp
@@ -16,6 +16,11 @@ using namespace farmhub::kernel;
 
 namespace farmhub::peripherals::environment {
 
+/**
+ * @brief Support for DS18B20 soil temperature sensor.
+ *
+ * Note: Needs a 4.7k pull-up resistor between the data and power lines.
+ */
 class Ds18B20SoilSensorComponent
     : public Component,
       public TelemetryProvider {
@@ -26,10 +31,9 @@ public:
         gpio_num_t pin)
         : Component(name, mqttRoot) {
 
-        Log.infoln("Initializing DS18B20 environment sensor on pin %d",
+        Log.infoln("Initializing DS18B20 soil temperature sensor on pin %d",
             pin);
 
-        pinMode(pin, INPUT_PULLUP);
         oneWire.begin(pin);
 
         // locate devices on the bus

--- a/src/peripherals/environment/Environment.hpp
+++ b/src/peripherals/environment/Environment.hpp
@@ -12,6 +12,7 @@ using namespace farmhub::kernel;
 using namespace farmhub::kernel::drivers;
 using std::make_unique;
 using std::unique_ptr;
+
 namespace farmhub::peripherals::environment {
 
 template <typename TComponent>

--- a/src/peripherals/environment/SoilMoistureSensor.hpp
+++ b/src/peripherals/environment/SoilMoistureSensor.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <memory>
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include <ArduinoLog.h>
+
+#include <devices/Peripheral.hpp>
+#include <kernel/Component.hpp>
+#include <kernel/Telemetry.hpp>
+
+using namespace farmhub::devices;
+using namespace farmhub::kernel;
+using namespace farmhub::peripherals;
+
+namespace farmhub::peripherals::environment {
+
+class SoilMoistureSensorDeviceConfig
+    : public ConfigurationSection {
+public:
+    Property<gpio_num_t> pin { this, "pin", GPIO_NUM_NC };
+    // These values need calibrating for each sensor
+    Property<uint16_t> air { this, "air", 3000 };
+    Property<uint16_t> water { this, "water", 1000 };
+};
+
+class SoilMoistureSensorComponent
+    : public Component,
+      public TelemetryProvider {
+public:
+    SoilMoistureSensorComponent(
+        const String& name,
+        shared_ptr<MqttDriver::MqttRoot> mqttRoot,
+        const SoilMoistureSensorDeviceConfig& config)
+        : Component(name, mqttRoot)
+        , airValue(config.air.get())
+        , waterValue(config.water.get())
+        , pin(config.pin.get()) {
+
+        Log.infoln("Initializing soil moisture sensor on pin %d; air value: %d; water value: %d",
+            pin, airValue, waterValue);
+
+        pinMode(pin, INPUT);
+    }
+
+    void populateTelemetry(JsonObject& json) override {
+        uint16_t soilMoistureValue = analogRead(pin);
+        Log.verboseln("Soil moisture value: %d",
+            soilMoistureValue);
+
+        const double run = waterValue - airValue;
+        const double rise = 100;
+        const double delta = soilMoistureValue - airValue;
+        double moisture = (delta * rise) / run;
+
+        json["moisture"] = moisture;
+    }
+
+private:
+    const int airValue;
+    const int waterValue;
+    gpio_num_t pin;
+};
+
+class SoilMoistureSensor
+    : public Peripheral<EmptyConfiguration> {
+public:
+    SoilMoistureSensor(const String& name, shared_ptr<MqttDriver::MqttRoot> mqttRoot, const SoilMoistureSensorDeviceConfig& config)
+        : Peripheral<EmptyConfiguration>(name, mqttRoot)
+        , sensor(name, mqttRoot, config) {
+    }
+
+    void populateTelemetry(JsonObject& telemetryJson) override {
+        sensor.populateTelemetry(telemetryJson);
+    }
+
+private:
+    SoilMoistureSensorComponent sensor;
+};
+
+class SoilMoistureSensorFactory
+    : public PeripheralFactory<SoilMoistureSensorDeviceConfig, EmptyConfiguration> {
+public:
+    SoilMoistureSensorFactory()
+        : PeripheralFactory<SoilMoistureSensorDeviceConfig, EmptyConfiguration>("environment:soil-moisture") {
+    }
+
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const String& name, const SoilMoistureSensorDeviceConfig& deviceConfig, shared_ptr<MqttDriver::MqttRoot> mqttRoot) override {
+        return std::make_unique<SoilMoistureSensor>(name, mqttRoot, deviceConfig);
+    }
+};
+
+}    // namespace farmhub::peripherals::environment


### PR DESCRIPTION
Support for the standard "Capacitive Soil Moisture Sensor v2.0". Air and soil values need calibrating per sensor.