### PR TITLE
Use named pins to configure devices

### DIFF
--- a/data-templates/chicken-door-mk6.json
+++ b/data-templates/chicken-door-mk6.json
@@ -1,28 +1,16 @@
 {
-  "instance": "test-mk6-8",
+  "instance": "chicken-door-test",
   "peripherals": [
-    {
-      "name": "flow-control-a",
-      "type": "flow-control",
-      "params": {
-        "valve": {
-          "motor": "a"
-        },
-        "flow-meter": {
-          "pin": 6
-        }
-      }
-    },
     {
       "name": "chicken-door-a",
       "type": "chicken-door",
       "params": {
         "motor": "b",
-        "openPin": 45,
-        "closedPin": 5,
+        "openPin": "B2",
+        "closedPin": "B1",
         "lightSensor": {
-          "scl": 47,
-          "sda": 21
+          "scl": "C2",
+          "sda": "C3"
         }
       }
     }

--- a/data-templates/flow-control-mk4.json
+++ b/data-templates/flow-control-mk4.json
@@ -7,7 +7,7 @@
       "params": {
         "valve": {},
         "flow-meter": {
-          "pin": 17
+          "pin": "FLOW"
         }
       }
     }

--- a/data-templates/flow-control-mk5.json
+++ b/data-templates/flow-control-mk5.json
@@ -9,7 +9,7 @@
           "motor": "a"
         },
         "flow-meter": {
-          "pin": 5
+          "pin": "A1"
         }
       }
     }

--- a/data-templates/flow-control-mk6-fully-equipped.json
+++ b/data-templates/flow-control-mk6-fully-equipped.json
@@ -9,7 +9,7 @@
           "motor": "a"
         },
         "flow-meter": {
-          "pin": 6
+          "pin": "A1"
         }
       }
     },
@@ -17,7 +17,7 @@
       "name": "soil-temperature",
       "type": "environment:ds18b20",
       "params": {
-        "pin": 21
+        "pin": "C3"
       }
     },
     {
@@ -25,10 +25,10 @@
       "type": "environment:soil-moisture",
       "params": {
         "air": 3017,
-        "pin": 14,
+        "pin": "C4",
         "water": 1105
       }
     }
   ],
-  "sleepWhenIdle": false
+  "sleepWhenIdle": true
 }

--- a/data-templates/flow-control-mk6.json
+++ b/data-templates/flow-control-mk6.json
@@ -9,7 +9,7 @@
           "motor": "a"
         },
         "flow-meter": {
-          "pin": 6
+          "pin": "A1"
         }
       }
     }

--- a/data-templates/htu21-external-environment-mk5.json
+++ b/data-templates/htu21-external-environment-mk5.json
@@ -5,8 +5,8 @@
       "name": "external-environment",
       "type": "environment:htu2x",
       "params": {
-        "sda": 35,
-        "scl": 36
+        "sda": "SDA",
+        "scl": "SCL"
       }
     }
   ]

--- a/src/devices/DeviceDefinition.hpp
+++ b/src/devices/DeviceDefinition.hpp
@@ -2,8 +2,13 @@
 
 #include <list>
 
+#include <Arduino.h>
+
 #include <SHT2x.h>
 #include <SHT31.h>
+
+#include <ArduinoJson.h>
+#include <ArduinoLog.h>
 
 #include <kernel/Kernel.hpp>
 #include <kernel/PcntManager.hpp>

--- a/src/devices/Pin.hpp
+++ b/src/devices/Pin.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <vector>
+
+#include <Arduino.h>
+
+#include <ArduinoJson.h>
+
+namespace farmhub::devices {
+
+class Pin {
+public:
+    static gpio_num_t registerPin(const String& name, gpio_num_t pin) {
+        GPIO_NUMBERS[name] = pin;
+        GPIO_NAMES[pin] = name;
+        return pin;
+    }
+
+    static gpio_num_t numberOf(const String& name) {
+        auto it = GPIO_NUMBERS.find(name);
+        if (it != GPIO_NUMBERS.end()) {
+            return it->second;
+        }
+        return GPIO_NUM_MAX;
+    }
+
+    static String nameOf(gpio_num_t pin) {
+        auto it = GPIO_NAMES.find(pin);
+        if (it == GPIO_NAMES.end()) {
+            String name = "GPIO_NUM_" + String(pin);
+            registerPin(name, pin);
+            return name;
+        } else {
+            return it->second;
+        }
+    }
+
+    static bool isRegistered(gpio_num_t pin) {
+        return GPIO_NAMES.find(pin) != GPIO_NAMES.end();
+    }
+
+private:
+    bool useName;
+
+    static std::map<gpio_num_t, String> GPIO_NAMES;
+    static std::map<String, gpio_num_t> GPIO_NUMBERS;
+};
+
+std::map<gpio_num_t, String> Pin::GPIO_NAMES;
+std::map<String, gpio_num_t> Pin::GPIO_NUMBERS;
+
+}    // namespace farmhub::devices
+
+namespace ArduinoJson {
+
+using farmhub::devices::Pin;
+
+template <>
+struct Converter<gpio_num_t> {
+    static void toJson(const gpio_num_t& src, JsonVariant dst) {
+        if (Pin::isRegistered(src)) {
+            dst.set(Pin::nameOf(src));
+        } else {
+            dst.set(static_cast<int>(src));
+        }
+    }
+
+    static gpio_num_t fromJson(JsonVariantConst src) {
+        if (src.is<const char*>()) {
+            return Pin::numberOf(src.as<const char*>());
+        } else {
+            return static_cast<gpio_num_t>(src.as<int>());
+        }
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<const char*>() || src.is<int>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/src/devices/UglyDucklingMk4.hpp
+++ b/src/devices/UglyDucklingMk4.hpp
@@ -9,12 +9,13 @@
 #include <kernel/drivers/Drv8801Driver.hpp>
 #include <kernel/drivers/LedDriver.hpp>
 
-#include <devices/DeviceDefinition.hpp>
-
 #include <peripherals/chicken_door/ChickenDoor.hpp>
 #include <peripherals/flow_control/FlowControl.hpp>
 #include <peripherals/flow_meter/FlowMeter.hpp>
 #include <peripherals/valve/Valve.hpp>
+
+#include <devices/DeviceDefinition.hpp>
+#include <devices/Pin.hpp>
 
 using namespace farmhub::kernel;
 using namespace farmhub::peripherals::chicken_door;
@@ -32,14 +33,34 @@ public:
     }
 };
 
+namespace pins {
+static gpio_num_t BOOT = Pin::registerPin("BOOT", GPIO_NUM_0);
+static gpio_num_t STATUS = Pin::registerPin("STATUS", GPIO_NUM_26);
+
+static gpio_num_t SOIL_MOISTURE = Pin::registerPin("SOIL_MOISTURE", GPIO_NUM_6);
+static gpio_num_t SOIL_TEMP = Pin::registerPin("SOIL_TEMP", GPIO_NUM_7);
+
+static gpio_num_t VALVE_EN = Pin::registerPin("VALVE_EN", GPIO_NUM_10);
+static gpio_num_t VALVE_PH = Pin::registerPin("VALVE_PH", GPIO_NUM_11);
+static gpio_num_t VALVE_FAULT = Pin::registerPin("VALVE_FAULT", GPIO_NUM_12);
+static gpio_num_t VALVE_SLEEP = Pin::registerPin("VALVE_SLEEP", GPIO_NUM_13);
+static gpio_num_t VALVE_MODE1 = Pin::registerPin("VALVE_MODE1", GPIO_NUM_14);
+static gpio_num_t VALVE_MODE2 = Pin::registerPin("VALVE_MODE2", GPIO_NUM_15);
+static gpio_num_t VALVE_CURRENT = Pin::registerPin("VALVE_CURRENT", GPIO_NUM_16);
+static gpio_num_t FLOW = Pin::registerPin("FLOW", GPIO_NUM_17);
+
+static gpio_num_t SDA = Pin::registerPin("SDA", GPIO_NUM_8);
+static gpio_num_t SCL = Pin::registerPin("SCL", GPIO_NUM_9);
+static gpio_num_t RXD0 = Pin::registerPin("RXD0", GPIO_NUM_44);
+static gpio_num_t TXD0 = Pin::registerPin("TXD0", GPIO_NUM_43);
+}    // namespace pins
+
 class UglyDucklingMk4 : public DeviceDefinition<Mk4Config> {
 public:
     UglyDucklingMk4()
         : DeviceDefinition<Mk4Config>(
-            // Status LED
-            GPIO_NUM_26,
-            // Boot pin
-            GPIO_NUM_0) {
+            pins::STATUS,
+            pins::BOOT) {
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {
@@ -66,13 +87,13 @@ public:
 
     Drv8801Driver motorDriver {
         pwm,
-        GPIO_NUM_10,    // Enable
-        GPIO_NUM_11,    // Phase
-        GPIO_NUM_14,    // Mode1
-        GPIO_NUM_15,    // Mode2
-        GPIO_NUM_16,    // Current
-        GPIO_NUM_12,    // Fault
-        GPIO_NUM_13     // Sleep
+        pins::VALVE_EN,
+        pins::VALVE_PH,
+        pins::VALVE_MODE1,
+        pins::VALVE_MODE2,
+        pins::VALVE_CURRENT,
+        pins::VALVE_FAULT,
+        pins::VALVE_SLEEP
     };
 
     const ServiceRef<PwmMotorDriver> motor { "motor", motorDriver };

--- a/src/devices/UglyDucklingMk5.hpp
+++ b/src/devices/UglyDucklingMk5.hpp
@@ -7,12 +7,13 @@
 #include <kernel/drivers/Drv8874Driver.hpp>
 #include <kernel/drivers/LedDriver.hpp>
 
-#include <devices/DeviceDefinition.hpp>
-
 #include <peripherals/chicken_door/ChickenDoor.hpp>
 #include <peripherals/flow_control/FlowControl.hpp>
 #include <peripherals/flow_meter/FlowMeter.hpp>
 #include <peripherals/valve/Valve.hpp>
+
+#include <devices/DeviceDefinition.hpp>
+#include <devices/Pin.hpp>
 
 using namespace farmhub::kernel;
 using namespace farmhub::peripherals::chicken_door;
@@ -31,17 +32,56 @@ public:
     }
 };
 
+namespace pins {
+static gpio_num_t BOOT = Pin::registerPin("BOOT", GPIO_NUM_0);
+static gpio_num_t BATTERY = Pin::registerPin("BATTERY", GPIO_NUM_1);
+static gpio_num_t STATUS = Pin::registerPin("STATUS", GPIO_NUM_2);
+static gpio_num_t AIPROPI = Pin::registerPin("AIPROPI", GPIO_NUM_4);
+
+static gpio_num_t IOA1 = Pin::registerPin("A1", GPIO_NUM_5);
+static gpio_num_t IOA2 = Pin::registerPin("A2", GPIO_NUM_6);
+static gpio_num_t BIPROPI = Pin::registerPin("BIPROPI", GPIO_NUM_7);
+static gpio_num_t IOB1 = Pin::registerPin("B1", GPIO_NUM_15);
+static gpio_num_t AIN1 = Pin::registerPin("AIN1", GPIO_NUM_16);
+static gpio_num_t AIN2 = Pin::registerPin("AIN2", GPIO_NUM_17);
+static gpio_num_t BIN1 = Pin::registerPin("BIN1", GPIO_NUM_18);
+static gpio_num_t BIN2 = Pin::registerPin("BIN2", GPIO_NUM_8);
+
+static gpio_num_t DMINUS = Pin::registerPin("D-", GPIO_NUM_19);
+static gpio_num_t DPLUS = Pin::registerPin("D+", GPIO_NUM_20);
+
+static gpio_num_t IOB2 = Pin::registerPin("B2", GPIO_NUM_9);
+
+static gpio_num_t NSLEEP = Pin::registerPin("NSLEEP", GPIO_NUM_10);
+static gpio_num_t NFault = Pin::registerPin("NFault", GPIO_NUM_11);
+static gpio_num_t IOC4 = Pin::registerPin("C4", GPIO_NUM_12);
+static gpio_num_t IOC3 = Pin::registerPin("C3", GPIO_NUM_13);
+static gpio_num_t IOC2 = Pin::registerPin("C2", GPIO_NUM_14);
+static gpio_num_t IOC1 = Pin::registerPin("C1", GPIO_NUM_21);
+static gpio_num_t IOD4 = Pin::registerPin("D4", GPIO_NUM_47);
+static gpio_num_t IOD3 = Pin::registerPin("D3", GPIO_NUM_48);
+
+static gpio_num_t SDA = Pin::registerPin("SDA", GPIO_NUM_35);
+static gpio_num_t SCL = Pin::registerPin("SCL", GPIO_NUM_36);
+
+static gpio_num_t IOD1 = Pin::registerPin("D1", GPIO_NUM_37);
+static gpio_num_t IOD2 = Pin::registerPin("D2", GPIO_NUM_38);
+
+static gpio_num_t TCK = Pin::registerPin("TCK", GPIO_NUM_39);
+static gpio_num_t TDO = Pin::registerPin("TDO", GPIO_NUM_40);
+static gpio_num_t TDI = Pin::registerPin("TDI", GPIO_NUM_41);
+static gpio_num_t TMS = Pin::registerPin("TMS", GPIO_NUM_42);
+static gpio_num_t RXD0 = Pin::registerPin("RXD0", GPIO_NUM_44);
+static gpio_num_t TXD0 = Pin::registerPin("TXD0", GPIO_NUM_43);
+}    // namespace pins
+
 class UglyDucklingMk5 : public BatteryPoweredDeviceDefinition<Mk5Config> {
 public:
     UglyDucklingMk5()
         : BatteryPoweredDeviceDefinition<Mk5Config>(
-            // Status LED
-            GPIO_NUM_2,
-            // Boot pin
-            GPIO_NUM_0,
-            // Battery
-            // TODO Calibrate battery voltage divider ratio
-            GPIO_NUM_1, 2.4848) {
+            pins::STATUS,
+            pins::BOOT,
+            pins::BATTERY, 2.4848) {
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {
@@ -53,20 +93,20 @@ public:
 
     Drv8874Driver motorADriver {
         pwm,
-        GPIO_NUM_16,    // AIN1
-        GPIO_NUM_17,    // AIN2
-        GPIO_NUM_4,     // AIPROPI
-        GPIO_NUM_11,    // NFault
-        GPIO_NUM_10     // NSleep
+        pins::AIN1,
+        pins::AIN2,
+        pins::AIPROPI,
+        pins::NFault,
+        pins::NSLEEP
     };
 
     Drv8874Driver motorBDriver {
         pwm,
-        GPIO_NUM_18,    // BIN1
-        GPIO_NUM_8,     // BIN2
-        GPIO_NUM_7,     // BIPROPI
-        GPIO_NUM_11,    // NFault
-        GPIO_NUM_10     // NSleep
+        pins::BIN1,
+        pins::BIN2,
+        pins::AIPROPI,
+        pins::NFault,
+        pins::NSLEEP
     };
 
     const ServiceRef<PwmMotorDriver> motorA { "a", motorADriver };

--- a/src/devices/UglyDucklingMk6.hpp
+++ b/src/devices/UglyDucklingMk6.hpp
@@ -7,13 +7,14 @@
 #include <kernel/drivers/Drv8833Driver.hpp>
 #include <kernel/drivers/LedDriver.hpp>
 
-#include <devices/DeviceDefinition.hpp>
 #include <peripherals/Peripheral.hpp>
-
 #include <peripherals/chicken_door/ChickenDoor.hpp>
 #include <peripherals/flow_control/FlowControl.hpp>
 #include <peripherals/flow_meter/FlowMeter.hpp>
 #include <peripherals/valve/Valve.hpp>
+
+#include <devices/DeviceDefinition.hpp>
+#include <devices/Pin.hpp>
 
 using namespace farmhub::kernel;
 using namespace farmhub::peripherals::chicken_door;
@@ -31,16 +32,57 @@ public:
     }
 };
 
+namespace pins {
+static gpio_num_t BOOT = Pin::registerPin("BOOT", GPIO_NUM_0);
+static gpio_num_t BATTERY = Pin::registerPin("BATTERY", GPIO_NUM_1);
+static gpio_num_t STATUS = Pin::registerPin("STATUS", GPIO_NUM_2);
+static gpio_num_t STATUS2 = Pin::registerPin("STATUS2", GPIO_NUM_4);
+
+static gpio_num_t IOB1 = Pin::registerPin("B1", GPIO_NUM_5);
+static gpio_num_t IOA1 = Pin::registerPin("A1", GPIO_NUM_6);
+static gpio_num_t DIPROPI = Pin::registerPin("DIPROPI", GPIO_NUM_7);
+static gpio_num_t IOA2 = Pin::registerPin("A2", GPIO_NUM_15);
+static gpio_num_t AIN1 = Pin::registerPin("AIN1", GPIO_NUM_16);
+static gpio_num_t AIN2 = Pin::registerPin("AIN2", GPIO_NUM_17);
+static gpio_num_t BIN2 = Pin::registerPin("BIN2", GPIO_NUM_18);
+static gpio_num_t BIN1 = Pin::registerPin("BIN1", GPIO_NUM_8);
+
+static gpio_num_t DMINUS = Pin::registerPin("D-", GPIO_NUM_19);
+static gpio_num_t DPLUS = Pin::registerPin("D+", GPIO_NUM_20);
+
+static gpio_num_t LEDA_RED = Pin::registerPin("LEDA_RED", GPIO_NUM_46);
+static gpio_num_t LEDA_GREEN = Pin::registerPin("LEDA_GREEN", GPIO_NUM_9);
+
+static gpio_num_t NFault = Pin::registerPin("NFault", GPIO_NUM_11);
+static gpio_num_t BTN1 = Pin::registerPin("BTN1", GPIO_NUM_12);
+static gpio_num_t BTN2 = Pin::registerPin("BTN2", GPIO_NUM_13);
+static gpio_num_t IOC4 = Pin::registerPin("C4", GPIO_NUM_14);
+static gpio_num_t IOC3 = Pin::registerPin("C3", GPIO_NUM_21);
+static gpio_num_t IOC2 = Pin::registerPin("C2", GPIO_NUM_47);
+static gpio_num_t IOC1 = Pin::registerPin("C1", GPIO_NUM_48);
+static gpio_num_t IOB2 = Pin::registerPin("B2", GPIO_NUM_45);
+
+static gpio_num_t SDA = Pin::registerPin("SDA", GPIO_NUM_35);
+static gpio_num_t SCL = Pin::registerPin("SCL", GPIO_NUM_36);
+
+static gpio_num_t LEDB_GREEN = Pin::registerPin("LEDB_GREEN", GPIO_NUM_37);
+static gpio_num_t LEDB_RED = Pin::registerPin("LEDB_RED", GPIO_NUM_38);
+
+static gpio_num_t TCK = Pin::registerPin("TCK", GPIO_NUM_39);
+static gpio_num_t TDO = Pin::registerPin("TDO", GPIO_NUM_40);
+static gpio_num_t TDI = Pin::registerPin("TDI", GPIO_NUM_41);
+static gpio_num_t TMS = Pin::registerPin("TMS", GPIO_NUM_42);
+static gpio_num_t RXD0 = Pin::registerPin("RXD0", GPIO_NUM_44);
+static gpio_num_t TXD0 = Pin::registerPin("TXD0", GPIO_NUM_43);
+}    // namespace pins
+
 class UglyDucklingMk6 : public BatteryPoweredDeviceDefinition<Mk6Config> {
 public:
     UglyDucklingMk6()
         : BatteryPoweredDeviceDefinition<Mk6Config>(
-            // Status LED
-            GPIO_NUM_2,
-            // Boot pin
-            GPIO_NUM_0,
-            // Battery
-            GPIO_NUM_1, 1.2424) {
+            pins::STATUS,
+            pins::BOOT,
+            pins::BATTERY, 1.2424) {
         // Switch off strapping pin
         // TODO: Add a LED driver instead
         pinMode(GPIO_NUM_46, OUTPUT);
@@ -58,11 +100,11 @@ public:
 
     Drv8833Driver motorDriver {
         pwm,
-        GPIO_NUM_16,    // AIN1
-        GPIO_NUM_17,    // AIN2
-        GPIO_NUM_18,    // BIN1
-        GPIO_NUM_8,     // BIN2
-        GPIO_NUM_11,    // NFault
+        pins::AIN1,
+        pins::AIN2,
+        pins::BIN1,
+        pins::BIN2,
+        pins::NFault,
         GPIO_NUM_NC     // NSleep -- connected to LOADEN manually
     };
 


### PR DESCRIPTION
This lets us configure device pins using their names as well as their numbers:

```jsonc
{
  "instance": "chicken-door-test",
  "peripherals": [
    {
      "name": "chicken-door-a",
      "type": "chicken-door",
      "params": {
        "motor": "b",
        "openPin": "B2", // We can use names in strings,
        "closedPin": 5, // or raw pin numbers as numbers
        "lightSensor": {
          "scl": "C2",
          "sda": "C3"
        }
      }
    }
  ],
  "sleepWhenIdle": true
}
```