### PR TITLE
Allow configuring motor nSLEEP pin on MK6

### DIFF
--- a/src/devices/UglyDucklingMk6.hpp
+++ b/src/devices/UglyDucklingMk6.hpp
@@ -24,14 +24,6 @@ using namespace farmhub::peripherals::valve;
 
 namespace farmhub::devices {
 
-class Mk6Config
-    : public DeviceConfiguration {
-public:
-    Mk6Config()
-        : DeviceConfiguration("mk6") {
-    }
-};
-
 namespace pins {
 static gpio_num_t BOOT = Pin::registerPin("BOOT", GPIO_NUM_0);
 static gpio_num_t BATTERY = Pin::registerPin("BATTERY", GPIO_NUM_1);
@@ -76,6 +68,20 @@ static gpio_num_t RXD0 = Pin::registerPin("RXD0", GPIO_NUM_44);
 static gpio_num_t TXD0 = Pin::registerPin("TXD0", GPIO_NUM_43);
 }    // namespace pins
 
+class Mk6Config
+    : public DeviceConfiguration {
+public:
+    Mk6Config()
+        : DeviceConfiguration("mk6") {
+    }
+
+    /**
+     * @brief The built-in motor driver's nSLEEP pin can be manually set by a jumper,
+     * but can be connected to a GPIO pin, too. Defaults to C4.
+     */
+    Property<gpio_num_t> motorNSleepPin { this, "motorNSleepPin", pins::IOC4 };
+};
+
 class UglyDucklingMk6 : public BatteryPoweredDeviceDefinition<Mk6Config> {
 public:
     UglyDucklingMk6()
@@ -105,7 +111,7 @@ public:
         pins::BIN1,
         pins::BIN2,
         pins::NFault,
-        GPIO_NUM_NC     // NSleep -- connected to LOADEN manually
+        config.motorNSleepPin.get()
     };
 
     const ServiceRef<PwmMotorDriver> motorA { "a", motorDriver.getMotorA() };

--- a/src/kernel/drivers/Drv8833Driver.hpp
+++ b/src/kernel/drivers/Drv8833Driver.hpp
@@ -72,12 +72,6 @@ private:
         }
 
         void drive(MotorPhase phase, double duty = 1) override {
-            if (duty == 0 && canSleep) {
-                Log.traceln("Stopping motor");
-                sleep();
-                return;
-            }
-
             int dutyValue = static_cast<int>((in1Channel.maxValue() + in1Channel.maxValue() * duty) / 2);
             Log.traceln("Driving motor %s on pins %d/%d at %d%% (duty = %d)",
                 phase == MotorPhase::FORWARD ? "forward" : "reverse",
@@ -97,7 +91,9 @@ private:
                     break;
             }
 
-            if (canSleep) {
+            if (duty == 0) {
+                sleep();
+            } else {
                 wakeUp();
             }
         }


### PR DESCRIPTION
On the MK6 the original design was to use a jumper to enable/disable the motor driver. This was in anticipation of no-motor utilization. That seems to be rare, and for motor installations we need to be able to bring the motor to a complete stop, so we can now configure what pin sleep is connected to.