### PR TITLE
Default to 'default' peripheral name

### DIFF
--- a/src/peripherals/Peripheral.hpp
+++ b/src/peripherals/Peripheral.hpp
@@ -190,8 +190,11 @@ public:
             return;
         }
 
-        const String& name = deviceConfig.name.get();
-        const String& factory = deviceConfig.type.get();
+        String name = deviceConfig.name.get();
+        if (name.isEmpty()) {
+            name = "default";
+        }
+        String factory = deviceConfig.type.get();
         try {
             unique_ptr<PeripheralBase> peripheral = createPeripheral(name, factory, deviceConfig.params.get().get());
             peripherals.push_back(move(peripheral));


### PR DESCRIPTION
When a peripheral is not given a name, use `default`.