### PR TITLE
Fix name of hold duty configuration

### DIFF
--- a/src/peripherals/flow_control/FlowControl.hpp
+++ b/src/peripherals/flow_control/FlowControl.hpp
@@ -93,7 +93,7 @@ public:
             strategy = createValveControlStrategy(
                 valveConfig.strategy.get(),
                 valveConfig.switchDuration.get(),
-                valveConfig.duty.get() / 100.0);
+                valveConfig.holdDuty.get() / 100.0);
         } catch (const std::exception& e) {
             throw PeripheralCreationException("failed to create strategy: " + String(e.what()));
         }

--- a/src/peripherals/valve/Valve.hpp
+++ b/src/peripherals/valve/Valve.hpp
@@ -76,7 +76,7 @@ public:
             strategy = createValveControlStrategy(
                 deviceConfig.strategy.get(),
                 deviceConfig.switchDuration.get(),
-                deviceConfig.duty.get() / 100.0);
+                deviceConfig.holdDuty.get() / 100.0);
         } catch (const std::exception& e) {
             throw PeripheralCreationException("failed to create strategy: " + String(e.what()));
         }

--- a/src/peripherals/valve/ValveConfig.hpp
+++ b/src/peripherals/valve/ValveConfig.hpp
@@ -22,14 +22,14 @@ enum class ValveControlStrategyType {
     Latching
 };
 
-static ValveControlStrategy* createValveControlStrategy(ValveControlStrategyType strategy, milliseconds switchDuration, double duty) {
+static ValveControlStrategy* createValveControlStrategy(ValveControlStrategyType strategy, milliseconds switchDuration, double holdDuty) {
     switch (strategy) {
         case ValveControlStrategyType::NormallyOpen:
-            return new NormallyOpenValveControlStrategy(switchDuration, duty);
+            return new NormallyOpenValveControlStrategy(switchDuration, holdDuty);
         case ValveControlStrategyType::NormallyClosed:
-            return new NormallyClosedValveControlStrategy(switchDuration, duty);
+            return new NormallyClosedValveControlStrategy(switchDuration, holdDuty);
         case ValveControlStrategyType::Latching:
-            return new LatchingValveControlStrategy(switchDuration, duty);
+            return new LatchingValveControlStrategy(switchDuration, holdDuty);
         default:
             throw std::runtime_error("Unknown strategy");
     }
@@ -50,7 +50,7 @@ public:
 
     Property<String> motor { this, "motor" };
     Property<ValveControlStrategyType> strategy;
-    Property<double> duty { this, "duty", 100 };
+    Property<double> holdDuty { this, "holdDuty", 50 };    // This is a percentage
     Property<milliseconds> switchDuration { this, "switchDuration", 500ms };
 };
 


### PR DESCRIPTION
It should have been called 'holdDuty' not 'duty'.

Fixes #125.