### PR TITLE
Fix slow log publishing over MQTT

### DIFF
--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -310,7 +310,7 @@ public:
                         json["level"] = record.level;
                         json["message"] = record.message;
                     },
-                    MqttDriver::Retention::NoRetain, MqttDriver::QoS::AtLeastOnce, ticks::max(), MqttDriver::LogPublish::Silent);
+                    MqttDriver::Retention::NoRetain, MqttDriver::QoS::AtLeastOnce, ticks::zero(), MqttDriver::LogPublish::Silent);
             });
         });
 

--- a/src/kernel/Concurrent.hpp
+++ b/src/kernel/Concurrent.hpp
@@ -26,6 +26,10 @@ protected:
 public:
     virtual void clear() = 0;
 
+    UBaseType_t size() {
+        return uxQueueMessagesWaiting(queue);
+    }
+
 protected:
 
     const String name;


### PR DESCRIPTION
We used to be waiting for logs to be published, which added a one second wait between log lines. This is now removed.