### PR TITLE
Disable battery option on MK5

### DIFF
--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -32,7 +32,6 @@ typedef farmhub::devices::Mk4Config TDeviceConfiguration;
 #include <devices/UglyDucklingMk5.hpp>
 typedef farmhub::devices::UglyDucklingMk5 TDeviceDefinition;
 typedef farmhub::devices::Mk5Config TDeviceConfiguration;
-#define HAS_BATTERY
 
 #elif defined(MK6)
 #include <devices/UglyDucklingMk6.hpp>

--- a/src/devices/UglyDucklingMk5.hpp
+++ b/src/devices/UglyDucklingMk5.hpp
@@ -75,13 +75,12 @@ static gpio_num_t RXD0 = Pin::registerPin("RXD0", GPIO_NUM_44);
 static gpio_num_t TXD0 = Pin::registerPin("TXD0", GPIO_NUM_43);
 }    // namespace pins
 
-class UglyDucklingMk5 : public BatteryPoweredDeviceDefinition<Mk5Config> {
+class UglyDucklingMk5 : public DeviceDefinition<Mk5Config> {
 public:
     UglyDucklingMk5()
-        : BatteryPoweredDeviceDefinition<Mk5Config>(
+        : DeviceDefinition<Mk5Config>(
             pins::STATUS,
-            pins::BOOT,
-            pins::BATTERY, 2.4848) {
+            pins::BOOT) {
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {


### PR DESCRIPTION
The device has a battery operated mode, but it doesn't work well and we'll never use it on any of the 10 instances in existence.