### PR TITLE
Assume the door hasn't moved when signal from switches is lost

### DIFF
--- a/src/peripherals/chicken_door/ChickenDoor.hpp
+++ b/src/peripherals/chicken_door/ChickenDoor.hpp
@@ -176,6 +176,12 @@ private:
     void runLoop(Task& task) {
         DoorState currentState = determineCurrentState();
         DoorState targetState = determineTargetState(currentState);
+        if (currentState == DoorState::NONE && targetState == lastState) {
+            // We have previously reached the target state, but we have lost the signal from the switches.
+            // We assume the door is still in the target state to prevent it from moving when it shouldn't.
+            currentState = lastState;
+        }
+
         if (currentState != targetState) {
             if (currentState != lastState) {
                 Log.trace("Going from state %d to %d (light level %.2f)",


### PR DESCRIPTION
This is to prevent the door from moving when it shouldn't be (like when the wind temporarily moves the magnet away from the Hall-sensor).