### PR TITLE
Fix light sensor init

### DIFF
--- a/src/peripherals/light_sensor/Bh1750.hpp
+++ b/src/peripherals/light_sensor/Bh1750.hpp
@@ -41,7 +41,7 @@ public:
         const String& name,
         shared_ptr<MqttDriver::MqttRoot> mqttRoot,
         I2CManager& i2c,
-        const I2CConfig& config,
+        I2CConfig config,
         seconds measurementFrequency,
         seconds latencyInterval)
         : LightSensorComponent(name, mqttRoot, measurementFrequency, latencyInterval) {

--- a/src/peripherals/light_sensor/Tsl2591.hpp
+++ b/src/peripherals/light_sensor/Tsl2591.hpp
@@ -42,7 +42,7 @@ public:
         const String& name,
         shared_ptr<MqttDriver::MqttRoot> mqttRoot,
         I2CManager& i2c,
-        const I2CConfig& config,
+        I2CConfig config,
         seconds measurementFrequency,
         seconds latencyInterval)
         : LightSensorComponent(name, mqttRoot, measurementFrequency, latencyInterval) {


### PR DESCRIPTION
C++. :(

At least with the TSL2591 light sensor, it often happened that the device measured astronomically high amounts of light, like 9.4e163 etc. Turns out the measurement frequency was messed up due to a C++ problem.