### PR TITLE
Increase MQTT publish queue size

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,9 @@ extends = base
 platform = native@~1.2.1
 test_framework = googletest
 debug_test = *
+lib_deps =
+    ${base.lib_deps}
+    googletest@^1.14.0
 
 [esp32base]
 extends = base

--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -353,7 +353,7 @@ public:
 
         Task::loop("telemetry", 8192, [this](Task& task) {
             publishTelemetry();
-            // TODO Configure telemetry these intervals
+            // TODO Configure these telemetry intervals
             // Publishing interval
             const auto interval = 1min;
             // We always wait at least this much between telemetry updates

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -181,7 +181,7 @@ public:
         Property<String> host { this, "host", "" };
         Property<unsigned int> port { this, "port", 1883 };
         Property<String> clientId { this, "clientId", "" };
-        Property<size_t> queueSize { this, "queueSize", 16 };
+        Property<size_t> queueSize { this, "queueSize", 128 };
         ArrayProperty<String> serverCert { this, "serverCert" };
         ArrayProperty<String> clientCert { this, "clientCert" };
         ArrayProperty<String> clientKey { this, "clientKey" };


### PR DESCRIPTION
This is a temporary fix for log messages taking over MQTT. The proper solution is to implement:

- #161
