### PR TITLE
Validate format strings in log messages

### DIFF
--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -201,12 +201,12 @@ public:
         Serial0.begin(115200);
 #endif
         Log.setConsumer(this);
-        Log.info(F("  ______                   _    _       _"));
-        Log.info(F(" |  ____|                 | |  | |     | |"));
-        Log.info(F(" | |__ __ _ _ __ _ __ ___ | |__| |_   _| |__"));
-        Log.info(F(" |  __/ _` | '__| '_ ` _ \\|  __  | | | | '_ \\"));
-        Log.info(F(" | | | (_| | |  | | | | | | |  | | |_| | |_) |"));
-        Log.info(F(" |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s"), VERSION);
+        Log.log(Level::Info, F("  ______                   _    _       _"));
+        Log.log(Level::Info, F(" |  ____|                 | |  | |     | |"));
+        Log.log(Level::Info, F(" | |__ __ _ _ __ _ __ ___ | |__| |_   _| |__"));
+        Log.log(Level::Info, F(" |  __/ _` | '__| '_ ` _ \\|  __  | | | | '_ \\"));
+        Log.log(Level::Info, F(" | | | (_| | |  | | | | | | |  | | |_| | |_) |"));
+        Log.log(Level::Info, F(" |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s"), VERSION);
     }
 
     void consumeLog(Level level, const char* message) override {
@@ -365,13 +365,13 @@ public:
 
         kernel.getKernelReadyState().set();
 
-        Log.info("Device ready in %.2f s (kernel version %s on %s instance '%s' with hostname '%s' and IP '%p')",
+        Log.info("Device ready in %.2f s (kernel version %s on %s instance '%s' with hostname '%s' and IP '%s')",
             millis() / 1000.0,
             kernel.version.c_str(),
             deviceConfig.model.get().c_str(),
             deviceConfig.instance.get().c_str(),
-            deviceConfig.getHostname(),
-            WiFi.localIP());
+            deviceConfig.getHostname().c_str(),
+            WiFi.localIP().toString().c_str());
     }
 
 private:

--- a/src/kernel/Command.hpp
+++ b/src/kernel/Command.hpp
@@ -79,7 +79,7 @@ public:
     void handle(const JsonObject& request, JsonObject& response) override {
         seconds duration = seconds(request["duration"].as<long>());
         esp_sleep_enable_timer_wakeup(((microseconds) duration).count());
-        Log.info("Sleeping for %ld seconds in light sleep mode",
+        Log.info("Sleeping for %lld seconds in light sleep mode",
             duration.count());
         esp_deep_sleep_start();
     }

--- a/src/kernel/Kernel.hpp
+++ b/src/kernel/Kernel.hpp
@@ -71,7 +71,7 @@ public:
             version.c_str(),
             deviceConfig.model.get().c_str(),
             deviceConfig.instance.get().c_str(),
-            deviceConfig.getHostname());
+            deviceConfig.getHostname().c_str());
 
         // TODO Allocate less memory when FARMHUB_DEBUG is disabled
         Task::loop("status-update", 2560, [this](Task&) { updateState(); });
@@ -168,7 +168,7 @@ private:
 
         if (newState != state) {
             Log.debug("Kernel state changed from %d to %d",
-                state, newState);
+                static_cast<int>(state), static_cast<int>(newState));
             state = newState;
             switch (newState) {
                 case KernelState::BOOTING:

--- a/src/kernel/Log.hpp
+++ b/src/kernel/Log.hpp
@@ -52,43 +52,43 @@ public:
 
 class FarmhubLog : public LogConsumer {
 public:
-    template <class T, typename... Args>
-    inline void fatal(T format, Args... args) {
+    template <typename... Args>
+    inline void fatal(const char* format, Args... args) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_FATAL
         log(Level::Fatal, format, args...);
 #endif
     }
 
-    template <class T, typename... Args>
-    inline void error(T format, Args... args) {
+    template <typename... Args>
+    inline void error(const char* format, Args... args) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_ERROR
         log(Level::Error, format, args...);
 #endif
     }
 
-    template <class T, typename... Args>
-    inline void warn(T format, Args... args) {
+    template <typename... Args>
+    inline void warn(const char* format, Args... args) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_WARNING
         log(Level::Warning, format, args...);
 #endif
     }
 
-    template <class T, typename... Args>
-    inline void info(T format, Args... args) {
+    template <typename... Args>
+    inline void info(const char* format, Args... args) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_INFO
         log(Level::Info, format, args...);
 #endif
     }
 
-    template <class T, typename... Args>
-    inline void debug(T format, Args... args) {
+    template <typename... Args>
+    inline void debug(const char* format, Args... args) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_DEBUG
         log(Level::Debug, format, args...);
 #endif
     }
 
-    template <class T, typename... Args>
-    inline void trace(T format, Args... args) {
+    template <typename... Args>
+    inline void trace(const char* format, Args... args) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_TRACE
         log(Level::Trace, format, args...);
 #endif

--- a/src/kernel/Log.hpp
+++ b/src/kernel/Log.hpp
@@ -52,72 +52,76 @@ public:
 
 class FarmhubLog : public LogConsumer {
 public:
-    template <typename... Args>
-    inline void fatal(const char* format, Args... args) {
+    inline void __attribute__((format(printf, 2, 3))) fatal(const char* format, ...) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_FATAL
-        log(Level::Fatal, format, args...);
+        va_list args;
+        va_start(args, format);
+        logImpl(Level::Fatal, format, args);
+        va_end(args);
 #endif
     }
 
-    template <typename... Args>
-    inline void error(const char* format, Args... args) {
+    inline void __attribute__((format(printf, 2, 3))) error(const char* format, ...) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_ERROR
-        log(Level::Error, format, args...);
+        va_list args;
+        va_start(args, format);
+        logImpl(Level::Error, format, args);
+        va_end(args);
 #endif
     }
 
-    template <typename... Args>
-    inline void warn(const char* format, Args... args) {
+    inline void __attribute__((format(printf, 2, 3))) warn(const char* format, ...) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_WARNING
-        log(Level::Warning, format, args...);
+        va_list args;
+        va_start(args, format);
+        logImpl(Level::Warning, format, args);
+        va_end(args);
 #endif
     }
 
-    template <typename... Args>
-    inline void info(const char* format, Args... args) {
+    inline void __attribute__((format(printf, 2, 3))) info(const char* format, ...) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_INFO
-        log(Level::Info, format, args...);
+        va_list args;
+        va_start(args, format);
+        logImpl(Level::Info, format, args);
+        va_end(args);
 #endif
     }
 
-    template <typename... Args>
-    inline void debug(const char* format, Args... args) {
+    inline void __attribute__((format(printf, 2, 3))) debug(const char* format, ...) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_DEBUG
-        log(Level::Debug, format, args...);
+        va_list args;
+        va_start(args, format);
+        logImpl(Level::Debug, format, args);
+        va_end(args);
 #endif
     }
 
-    template <typename... Args>
-    inline void trace(const char* format, Args... args) {
+    inline void __attribute__((format(printf, 2, 3))) trace(const char* format, ...) {
 #if FARMHUB_LOG_LEVEL >= FARMHUB_LOG_LEVEL_TRACE
-        log(Level::Trace, format, args...);
+        va_list args;
+        va_start(args, format);
+        logImpl(Level::Trace, format, args);
+        va_end(args);
 #endif
     }
 
-    template <typename... Args>
-    void log(Level level, const __FlashStringHelper* format, Args... args) {
+    void __attribute__((format(printf, 3, 4))) log(Level level, const char* format, ...) {
+        va_list args;
+        va_start(args, format);
+        logImpl(level, format, args);
+        va_end(args);
+    }
+
+    void log(Level level, const __FlashStringHelper* format, ...) {
         int len = strnlen_P(reinterpret_cast<const char*>(format), bufferSize - 1);
         char formatInSram[len + 1];
         strncpy_P(formatInSram, reinterpret_cast<const char*>(format), len);
         formatInSram[len] = '\0';
-        log(level, formatInSram, args...);
-    }
-
-    template <typename... Args>
-    void log(Level level, const char* format, Args... args) {
-        int size = snprintf(nullptr, 0, format, args...);
-        if (size <= 0) {
-            return;
-        }
-
-        if (size < bufferSize) {
-            Lock lock(bufferMutex);
-            logWithBuffer(buffer, size + 1, level, format, args...);
-        } else {
-            char* localBuffer = new char[size + 1];
-            logWithBuffer(localBuffer, size + 1, level, format, args...);
-            delete localBuffer;
-        }
+        va_list args;
+        va_start(args, format);
+        logImpl(level, formatInSram, args);
+        va_end(args);
     }
 
     void setConsumer(LogConsumer* consumer) {
@@ -132,9 +136,28 @@ public:
     }
 
 private:
-    template <typename... Args>
-    void logWithBuffer(char* buffer, size_t size, Level level, const char* format, Args... args) {
-        snprintf(buffer, size, format, args...);
+    void logImpl(Level level, const char* format, va_list args) {
+        if (static_cast<int>(level) < FARMHUB_LOG_LEVEL) {
+            return;
+        }
+
+        int size = vsnprintf(nullptr, 0, format, args);
+        if (size <= 0) {
+            return;
+        }
+
+        if (size < bufferSize) {
+            Lock lock(bufferMutex);
+            logWithBuffer(buffer, size + 1, level, format, args);
+        } else {
+            char* localBuffer = new char[size + 1];
+            logWithBuffer(localBuffer, size + 1, level, format, args);
+            delete localBuffer;
+        }
+    }
+
+    void logWithBuffer(char* buffer, size_t size, Level level, const char* format, va_list args) {
+        vsnprintf(buffer, size, format, args);
         consumer.load()->consumeLog(level, buffer);
     }
 

--- a/src/kernel/Watchdog.hpp
+++ b/src/kernel/Watchdog.hpp
@@ -34,7 +34,7 @@ public:
         });
         callback(WatchdogState::Started);
         Log.debug("Watchdog started with a timeout of %.2f seconds",
-            duration_cast<milliseconds>(timeout).count() / 1000);
+            duration_cast<milliseconds>(timeout).count() / 1000.0);
     }
 
     void cancel() {

--- a/src/kernel/drivers/MqttDriver.hpp
+++ b/src/kernel/drivers/MqttDriver.hpp
@@ -91,7 +91,7 @@ public:
                 // Clear topic and wait for it to be cleared
                 auto clearStatus = mqtt.clear(fullTopic(suffix), Retention::Retain, QoS::ExactlyOnce, std::chrono::seconds { 5 });
                 if (clearStatus != PublishStatus::Success) {
-                    Log.error("MQTT: Failed to clear retained command topic '%s', status: %d", suffix.c_str(), clearStatus);
+                    Log.error("MQTT: Failed to clear retained command topic '%s', status: %d", suffix.c_str(), static_cast<int>(clearStatus));
                 }
 
                 JsonDocument responseDoc;
@@ -223,7 +223,7 @@ private:
             String serializedJson;
             serializeJsonPretty(json, serializedJson);
             Log.debug("MQTT: Queuing topic '%s'%s (qos = %d): %s",
-                topic.c_str(), (retain == Retention::Retain ? " (retain)" : ""), qos, serializedJson.c_str());
+                topic.c_str(), (retain == Retention::Retain ? " (retain)" : ""), static_cast<int>(qos), serializedJson.c_str());
         }
 #endif
         String payload;
@@ -434,7 +434,7 @@ private:
     // Actually subscribe to the given topic
     bool registerSubscriptionWithMqtt(const Subscription& subscription) {
         Log.debug("MQTT: Subscribing to topic '%s' (qos = %d)",
-            subscription.topic.c_str(), subscription.qos);
+            subscription.topic.c_str(), static_cast<int>(subscription.qos));
         bool success = mqttClient.subscribe(subscription.topic, static_cast<int>(subscription.qos), [](const String& payload, const size_t size) {
             // Global handler will take care of putting the received message on the incoming queue
         });

--- a/src/kernel/drivers/RtcDriver.hpp
+++ b/src/kernel/drivers/RtcDriver.hpp
@@ -94,10 +94,10 @@ private:
         } else {
             MdnsRecord ntpServer;
             if (mdns.lookupService("ntp", "udp", ntpServer, trustMdnsCache)) {
-                Log.info("RTC: using NTP server %s:%d (%p) from mDNS",
+                Log.info("RTC: using NTP server %s:%d (%s) from mDNS",
                     ntpServer.hostname.c_str(),
                     ntpServer.port,
-                    ntpServer.ip);
+                    ntpServer.ip.toString().c_str());
                 ntpClient = new NTPClient(udp, ntpServer.ip);
             } else {
                 Log.info("RTC: no NTP server configured, using default");

--- a/src/kernel/drivers/WiFiDriver.hpp
+++ b/src/kernel/drivers/WiFiDriver.hpp
@@ -42,10 +42,10 @@ public:
             ARDUINO_EVENT_WIFI_STA_CONNECTED);
         WiFi.onEvent(
             [this, &networkReady](WiFiEvent_t event, WiFiEventInfo_t info) {
-                Log.info("WiFi: got IP %p, netmask %p, gateway %p",
-                    IPAddress(info.got_ip.ip_info.ip.addr),
-                    IPAddress(info.got_ip.ip_info.netmask.addr),
-                    IPAddress(info.got_ip.ip_info.gw.addr));
+                Log.info("WiFi: got IP %s, netmask %s, gateway %s",
+                    IPAddress(info.got_ip.ip_info.ip.addr).toString().c_str(),
+                    IPAddress(info.got_ip.ip_info.netmask.addr).toString().c_str(),
+                    IPAddress(info.got_ip.ip_info.gw.addr).toString().c_str());
                 reconnectQueue.clear();
                 networkReady.set();
             },

--- a/src/peripherals/chicken_door/ChickenDoor.hpp
+++ b/src/peripherals/chicken_door/ChickenDoor.hpp
@@ -185,7 +185,7 @@ private:
         if (currentState != targetState) {
             if (currentState != lastState) {
                 Log.trace("Going from state %d to %d (light level %.2f)",
-                    currentState, targetState, lightSensor.getCurrentLevel());
+                    static_cast<int>(currentState), static_cast<int>(targetState), lightSensor.getCurrentLevel());
                 watchdog.restart();
             }
             switch (targetState) {
@@ -202,7 +202,7 @@ private:
         } else {
             if (currentState != lastState) {
                 Log.trace("Reached state %d (light level %.2f)",
-                    currentState, lightSensor.getCurrentLevel());
+                    static_cast<int>(currentState), lightSensor.getCurrentLevel());
                 watchdog.cancel();
                 motor.stop();
                 mqttRoot->publish("events/state", [=](JsonObject& json) {
@@ -239,8 +239,8 @@ private:
                         if (arg.state == DoorState::NONE) {
                             Log.info("Override cancelled");
                         } else {
-                            Log.info("Override received: %d duration: %d sec",
-                                arg.state, duration_cast<seconds>(arg.until - system_clock::now()).count());
+                            Log.info("Override received: %d duration: %lld sec",
+                                static_cast<int>(arg.state), duration_cast<seconds>(arg.until - system_clock::now()).count());
                         }
                         {
                             Lock lock(stateMutex);

--- a/src/peripherals/valve/ValveComponent.hpp
+++ b/src/peripherals/valve/ValveComponent.hpp
@@ -286,7 +286,7 @@ private:
         if (state == ValveState::NONE) {
             Log.info("Clearing override for valve '%s'", name.c_str());
         } else {
-            Log.info("Overriding valve '%s' to state %d until %ld",
+            Log.info("Overriding valve '%s' to state %d until %lld",
                 name.c_str(), static_cast<int>(state), until.time_since_epoch().count());
         }
         updateQueue.put(OverrideSpec { state, until });

--- a/src/peripherals/valve/ValveSchedule.hpp
+++ b/src/peripherals/valve/ValveSchedule.hpp
@@ -63,15 +63,15 @@ struct Converter<ValveSchedule> {
         strptime(src["start"].as<const char*>(), "%FT%TZ", &startTm);
         auto startTime = mktime(&startTm);
         auto startLocalTime = system_clock::from_time_t(startTime);
-        seconds period = seconds(src["period"].as<int>());
-        seconds duration = seconds(src["duration"].as<int>());
+        seconds period = seconds(src["period"].as<long long int>());
+        seconds duration = seconds(src["duration"].as<long long int>());
         return ValveSchedule(startLocalTime, period, duration);
     }
 
     static bool checkJson(JsonVariantConst src) {
         return src["start"].is<const char*>()
-            && src["period"].is<int>()
-            && src["duration"].is<int>();
+            && src["period"].is<long long int>()
+            && src["duration"].is<long long int>();
     }
 };
 

--- a/src/peripherals/valve/ValveSchedule.hpp
+++ b/src/peripherals/valve/ValveSchedule.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <chrono>
+
+#include <ArduinoJson.h>
+
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+namespace farmhub::peripherals::valve {
+
+class ValveSchedule {
+public:
+    ValveSchedule(
+        time_point<system_clock> start,
+        seconds period,
+        seconds duration)
+        : start(start)
+        , period(period)
+        , duration(duration) {
+    }
+
+    time_point<system_clock> getStart() const {
+        return start;
+    }
+
+    seconds getPeriod() const {
+        return period;
+    }
+
+    seconds getDuration() const {
+        return duration;
+    }
+
+private:
+    time_point<system_clock> start;
+    seconds period;
+    seconds duration;
+};
+
+}    // namespace farmhub::peripherals::valve
+
+namespace ArduinoJson {
+
+using farmhub::peripherals::valve::ValveSchedule;
+template <>
+struct Converter<ValveSchedule> {
+    static void toJson(const ValveSchedule& src, JsonVariant dst) {
+        JsonObject obj = dst.to<JsonObject>();
+        auto startLocalTime = src.getStart();
+        auto startTime = system_clock::to_time_t(startLocalTime);
+        tm startTm;
+        localtime_r(&startTime, &startTm);
+        char buf[64];
+        strftime(buf, sizeof(buf), "%FT%TZ", &startTm);
+        obj["start"] = buf;
+        obj["period"] = src.getPeriod().count();
+        obj["duration"] = src.getDuration().count();
+    }
+
+    static ValveSchedule fromJson(JsonVariantConst src) {
+        tm startTm;
+        strptime(src["start"].as<const char*>(), "%FT%TZ", &startTm);
+        auto startTime = mktime(&startTm);
+        auto startLocalTime = system_clock::from_time_t(startTime);
+        seconds period = seconds(src["period"].as<int>());
+        seconds duration = seconds(src["duration"].as<int>());
+        return ValveSchedule(startLocalTime, period, duration);
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src["start"].is<const char*>()
+            && src["period"].is<int>()
+            && src["duration"].is<int>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/src/peripherals/valve/ValveScheduler.hpp
+++ b/src/peripherals/valve/ValveScheduler.hpp
@@ -5,6 +5,7 @@
 #include <list>
 
 #include <kernel/Time.hpp>
+#include <peripherals/valve/ValveSchedule.hpp>
 
 using namespace std::chrono;
 using namespace farmhub::kernel;
@@ -25,35 +26,6 @@ bool convertToJson(const ValveState& src, JsonVariant dst) {
 void convertFromJson(JsonVariantConst src, ValveState& dst) {
     dst = static_cast<ValveState>(src.as<int>());
 }
-
-class ValveSchedule {
-public:
-    ValveSchedule(
-        time_point<system_clock> start,
-        seconds period,
-        seconds duration)
-        : start(start)
-        , period(period)
-        , duration(duration) {
-    }
-
-    time_point<system_clock> getStart() const {
-        return start;
-    }
-
-    seconds getPeriod() const {
-        return period;
-    }
-
-    seconds getDuration() const {
-        return duration;
-    }
-
-private:
-    time_point<system_clock> start;
-    seconds period;
-    seconds duration;
-};
 
 struct ValveStateUpdate {
     ValveState state;


### PR DESCRIPTION
Apparently we had a bunch of badly phrased format strings in the code; these are now fixed. Moreover, we now validate them by the compiler, so we won't be able to introduce more such violations.

The incorrect format strings were definitely behind problems like the garbage printed instead of the hostname during boot. But they might have been responsible for more problematic behaviors, too.