### PR TITLE
Start WiFi before configuring it

### DIFF
--- a/src/kernel/drivers/WiFiDriver.hpp
+++ b/src/kernel/drivers/WiFiDriver.hpp
@@ -25,6 +25,7 @@ public:
         : networkReady(networkReady) {
         Log.debug("WiFi: initializing");
 
+        WiFi.begin();
         if (powerSaveMode) {
             auto listenInterval = 50;
             Log.debug("WiFi enabling power save mode, listen interval: %d",


### PR DESCRIPTION
This caused https://github.com/kivancsikert/ugly-duckling/releases/tag/0.31.0 to fail on boot when light sleep was enabled.