### PR TITLE
Optimize compiler output

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -44,6 +44,7 @@ build_unflags =
     ${base.build_unflags}
 build_flags =
     ${base.build_flags}
+    -O2
     -D WM_NODEBUG=1
     -D FARMHUB_REPORT_MEMORY
     -D ARDUINO_USB_CDC_ON_BOOT=1
@@ -76,6 +77,7 @@ lib_deps =
 [debug]
 build_type = debug
 build_flags =
+    -O0
     -D FARMHUB_DEBUG
     -D DUMP_MQTT
 


### PR DESCRIPTION
Use `-O2` when compiling release firmware.