### PR TITLE
Fix factory reset

### DIFF
--- a/src/kernel/Kernel.hpp
+++ b/src/kernel/Kernel.hpp
@@ -106,7 +106,6 @@ public:
 
     void performFactoryReset() {
         Log.printlnToSerial("Performing factory reset");
-        Log.flushSerial();
 
         statusLed.turnOn();
         delay(1000);
@@ -115,16 +114,13 @@ public:
         statusLed.turnOn();
 
         Log.printlnToSerial(" - Deleting the file system...");
-        Log.flushSerial();
         fs.reset();
 
         Log.printlnToSerial(" - Clearing NVS...");
-        Log.flushSerial();
 
         nvs_flash_erase();
 
         Log.printlnToSerial(" - Restarting...");
-        Log.flushSerial();
 
         ESP.restart();
     }

--- a/src/kernel/Log.hpp
+++ b/src/kernel/Log.hpp
@@ -135,14 +135,6 @@ public:
         printlnToSerial(message);
     }
 
-    void flushSerial() {
-        Serial.flush();
-        Serial1.flush();
-#if Serial != Serial0
-        Serial0.flush();
-#endif
-    }
-
     void printlnToSerial(const char* message = "") {
         Serial.println(message);
         Serial1.println(message);

--- a/src/kernel/drivers/SwitchManager.hpp
+++ b/src/kernel/drivers/SwitchManager.hpp
@@ -42,7 +42,7 @@ public:
             if (engaged) {
                 state->engagementStarted = system_clock::now();
                 state->engagementHandler(*state);
-            } else {
+            } else if (state->engagementStarted.time_since_epoch().count() > 0) {
                 auto duration = duration_cast<milliseconds>(system_clock::now() - state->engagementStarted);
                 state->releaseHandler(*state, duration);
             }


### PR DESCRIPTION
Factory reset was called at startup, but did not go through because of incorrect flushing of serial outputs. Now this works.

Fixes #198.