### PR TITLE
Controlled shutdown on low battery

### DIFF
--- a/src/peripherals/flow_control/FlowControl.hpp
+++ b/src/peripherals/flow_control/FlowControl.hpp
@@ -55,6 +55,10 @@ public:
         flowMeter.populateTelemetry(telemetryJson);
     }
 
+    void shutdown(const ShutdownParameters parameters) override {
+        valve.closeBeforeShutdown();
+    }
+
 private:
     ValveComponent valve;
     FlowMeterComponent flowMeter;

--- a/src/peripherals/valve/Valve.hpp
+++ b/src/peripherals/valve/Valve.hpp
@@ -53,6 +53,10 @@ public:
         valve.populateTelemetry(telemetry);
     }
 
+    void shutdown(const ShutdownParameters parameters) override {
+        valve.closeBeforeShutdown();
+    }
+
 private:
     ValveComponent valve;
 };

--- a/src/peripherals/valve/ValveComponent.hpp
+++ b/src/peripherals/valve/ValveComponent.hpp
@@ -288,6 +288,13 @@ public:
         }
     }
 
+    void closeBeforeShutdown() {
+        // TODO Lock the valve to prevent concurrent access
+        Log.info("Shutting down valve '%s', closing it",
+            name.c_str());
+        close();
+    }
+
 private:
     void override(ValveState state, time_point<system_clock> until) {
         if (state == ValveState::NONE) {


### PR DESCRIPTION
We already refuse to boot up when the battery is already low at boot. But we haven't so far handled the battery getting depleted while the device is in operation.

This change adds a recurring check and if the battery level drops below a threshold, and initiates a controlled shutdown. For now the only actual action while shutting down is closing open valves.