### PR TITLE
Fail better when ran out of I2C buses

### DIFF
--- a/main/kernel/I2CManager.hpp
+++ b/main/kernel/I2CManager.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <exception>
 #include <map>
 #include <utility>
-#include <exception>
 
 #include <Arduino.h>
 #include <Wire.h>
@@ -39,6 +39,9 @@ public:
             return *(it->second);
         } else {
             Log.trace("Creating new I2C bus for SDA: %d, SCL: %d", sda, scl);
+            if (nextBus >= 2) {
+                throw std::runtime_error("Maximum number of I2C buses reached");
+            }
             TwoWire* wire = new TwoWire(nextBus++);
             if (!wire->begin(sda, scl)) {
                 throw std::runtime_error(

--- a/main/peripherals/light_sensor/Bh1750.hpp
+++ b/main/peripherals/light_sensor/Bh1750.hpp
@@ -53,7 +53,8 @@ public:
         // TODO Make mode configurable
         // TODO What's the difference between one-time and continuous mode here?
         //      Can we save some battery by using one-time mode? Are we losing anything by doing so?
-        if (!sensor.begin(BH1750::CONTINUOUS_LOW_RES_MODE, config.address, &i2c.getWireFor(config))) {
+        TwoWire& wire = i2c.getWireFor(config);
+        if (!sensor.begin(BH1750::CONTINUOUS_LOW_RES_MODE, config.address, &wire)) {
             throw PeripheralCreationException("Failed to initialize BH1750 light sensor");
         }
 


### PR DESCRIPTION
When using more then the available 2 I2C buses on ESP32, give a more clear error message.