### PR TITLE
Allow resetting WiFi only

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -400,9 +400,12 @@ class Device {
 public:
     Device() {
         kernel.switches.onReleased("factory-reset", deviceDefinition.bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
-            if (duration >= 5s) {
+            if (duration >= 15s) {
                 Log.info("Factory reset triggered after %lld ms", duration.count());
-                kernel.performFactoryReset();
+                kernel.performFactoryReset(true);
+            } else if (duration >= 5s) {
+                Log.info("WiFi reset triggered after %lld ms", duration.count());
+                kernel.performFactoryReset(false);
             }
         });
 

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -108,7 +108,7 @@ public:
         fUpdate.close();
     }
 
-    void performFactoryReset() {
+    void performFactoryReset(bool completeReset) {
         Log.printlnToSerial("Performing factory reset");
 
         statusLed.turnOn();
@@ -117,15 +117,20 @@ public:
         delay(1000);
         statusLed.turnOn();
 
-        Log.printlnToSerial(" - Deleting the file system...");
-        fs.reset();
+        if (completeReset) {
+            delay(1000);
+            statusLed.turnOff();
+            delay(1000);
+            statusLed.turnOn();
+
+            Log.printlnToSerial(" - Deleting the file system...");
+            fs.reset();
+        }
 
         Log.printlnToSerial(" - Clearing NVS...");
-
         nvs_flash_erase();
 
         Log.printlnToSerial(" - Restarting...");
-
         ESP.restart();
     }
 


### PR DESCRIPTION
Pressing the `FLASH` button for 5+ seconds is reset WiFi only. Pressing it 15+ seconds is wipe file system, too.