### PR TITLE
Publish peripherals in device init message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SDKCONFIG_DEFAULTS "sdkconfig.defaults;sdkconfig.${UD_GEN_LOWER}.defaults")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-# idf_build_set_property(DEPENDENCIES_LOCK "dependencies.${UD_GEN_LOWER}.lock")
+idf_build_set_property(DEPENDENCIES_LOCK "dependencies.lock")
 
 # list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/components)
 list(APPEND EXTRA_COMPONENT_DIRS components)


### PR DESCRIPTION
Do not publish separate `init` messages per peripheral, but instead include their content in the device's `init` message. This allows the server to better understand what peripherals are present on the device.