### PR TITLE
Introduce sub-tags in logging

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -102,7 +102,7 @@ public:
         status.reserve(256);
         Task::loop("console", 3072, 1, [this](Task& task) {
             printStatus();
-            task.delayUntil(100ms);
+            task.delayUntil(250ms);
         });
     }
 

--- a/main/kernel/Concurrent.hpp
+++ b/main/kernel/Concurrent.hpp
@@ -60,7 +60,7 @@ public:
         TMessage* copy = new TMessage(std::forward<Args>(args)...);
         bool sentWithoutDropping = xQueueSend(this->queue, &copy, timeout.count()) == pdTRUE;
         if (!sentWithoutDropping) {
-            LOGW("Overflow in queue '%s', dropping message\n",
+            printf("Overflow in queue '%s', dropping message\n",
                 this->name.c_str());
             delete copy;
         }
@@ -137,7 +137,7 @@ public:
     bool offerIn(ticks timeout, const TMessage message) {
         bool sentWithoutDropping = xQueueSend(this->queue, &message, timeout.count()) == pdTRUE;
         if (!sentWithoutDropping) {
-            LOGW("Overflow in queue '%s', dropping message",
+            printf("Overflow in queue '%s', dropping message",
                 this->name.c_str());
         }
         return sentWithoutDropping;

--- a/main/kernel/Log.hpp
+++ b/main/kernel/Log.hpp
@@ -18,14 +18,17 @@ enum class Level {
     Verbose = 6,
 };
 
-#define FARMHUB_LOG(level, format, ...) \
-    ESP_LOG_LEVEL_LOCAL(level, "farmhub", format, ##__VA_ARGS__)
+#define LOGE(format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, "farmhub", format, ##__VA_ARGS__)
+#define LOGW(format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN, "farmhub", format, ##__VA_ARGS__)
+#define LOGI(format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO, "farmhub", format, ##__VA_ARGS__)
+#define LOGD(format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_DEBUG, "farmhub", format, ##__VA_ARGS__)
+#define LOGV(format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_VERBOSE, "farmhub", format, ##__VA_ARGS__)
 
-#define LOGE(format, ...) FARMHUB_LOG(ESP_LOG_ERROR, format, ##__VA_ARGS__)
-#define LOGW(format, ...) FARMHUB_LOG(ESP_LOG_WARN, format, ##__VA_ARGS__)
-#define LOGI(format, ...) FARMHUB_LOG(ESP_LOG_INFO, format, ##__VA_ARGS__)
-#define LOGD(format, ...) FARMHUB_LOG(ESP_LOG_DEBUG, format, ##__VA_ARGS__)
-#define LOGV(format, ...) FARMHUB_LOG(ESP_LOG_VERBOSE, format, ##__VA_ARGS__)
+#define LOGTE(tag, format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, "farmhub:" tag, format, ##__VA_ARGS__)
+#define LOGTW(tag, format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN, "farmhub:" tag, format, ##__VA_ARGS__)
+#define LOGTI(tag, format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO, "farmhub:" tag, format, ##__VA_ARGS__)
+#define LOGTD(tag, format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_DEBUG, "farmhub:" tag, format, ##__VA_ARGS__)
+#define LOGTV(tag, format, ...) ESP_LOG_LEVEL_LOCAL(ESP_LOG_VERBOSE, "farmhub:" tag, format, ##__VA_ARGS__)
 
 #ifndef FARMHUB_LOG_LEVEL
 #ifdef FARMHUB_DEBUG
@@ -43,11 +46,21 @@ void convertFromJson(JsonVariantConst src, Level& dst) {
 }
 
 static void initLogging() {
+    const char* logTags[] = {
+        "farmhub",
+        "farmhub:mqtt",
+        "farmhub:wifi",
+        "farmhub:rtc",
+        "farmhub:mdns",
+        "farmhub:nvs",
+    };
+    for (const char* tag : logTags) {
 #ifdef FARMHUB_DEBUG
-    esp_log_level_set("farmhub", ESP_LOG_DEBUG);
+        esp_log_level_set(tag, ESP_LOG_DEBUG);
 #else
-    esp_log_level_set("farmhub", ESP_LOG_INFO);
+        esp_log_level_set(tag, ESP_LOG_INFO);
 #endif
+    }
 }
 
 }    // namespace farmhub::kernel

--- a/main/kernel/NvsStore.hpp
+++ b/main/kernel/NvsStore.hpp
@@ -38,17 +38,17 @@ public:
     bool get(const char* key, T& value) {
         return withPreferences(true, [&]() {
             if (!preferences.isKey(key)) {
-                LOGV("NVS: get(%s) = not found",
+                LOGTV("nvs", "get(%s) = not found",
                     key);
                 return false;
             }
             String jsonString = preferences.getString(key);
-            LOGV("NVS: get(%s) = %s",
+            LOGTV("nvs", "get(%s) = %s",
                 key, jsonString.c_str());
             JsonDocument jsonDocument;
             deserializeJson(jsonDocument, jsonString);
             if (jsonDocument.isNull()) {
-                LOGE("NVS: get(%s) = invalid JSON",
+                LOGTE("nvs", "get(%s) = invalid JSON",
                     key);
                 return false;
             }
@@ -69,7 +69,7 @@ public:
             jsonDocument.set(value);
             String jsonString;
             serializeJson(jsonDocument, jsonString);
-            LOGV("NVS: set(%s) = %s",
+            LOGTV("nvs", "set(%s) = %s",
                 key, jsonString.c_str());
             return preferences.putString(key, jsonString.c_str());
         });
@@ -81,7 +81,7 @@ public:
 
     bool remove(const char* key) {
         return withPreferences(false, [&]() {
-            LOGV("NVS: remove(%s)",
+            LOGTV("nvs", "remove(%s)",
                 key);
             if (preferences.isKey(key)) {
                 return preferences.remove(key);
@@ -94,16 +94,16 @@ public:
 private:
     bool withPreferences(bool readOnly, std::function<bool()> action) {
         Lock lock(preferencesMutex);
-        LOGV("NVS: %s '%s'",
+        LOGTV("nvs", "%s '%s'",
             readOnly ? "read" : "write", name.c_str());
         if (!preferences.begin(name.c_str(), readOnly)) {
-            LOGE("NVS: failed to %s '%s'",
+            LOGTE("nvs", "failed to %s '%s'",
                 readOnly ? "read" : "write", name.c_str());
             return false;
         }
         bool result = action();
         preferences.end();
-        LOGV("NVS: finished %s '%s', result: %s",
+        LOGTV("nvs", "finished %s '%s', result: %s",
             readOnly ? "read" : "write", name.c_str(), result ? "true" : "false");
         return result;
     }

--- a/main/kernel/drivers/MdnsDriver.hpp
+++ b/main/kernel/drivers/MdnsDriver.hpp
@@ -34,21 +34,21 @@ public:
         , mdnsReady(mdnsReady) {
         // TODO Add error handling
         Task::run("mdns:init", 4096, [&wifi, &mdnsReady, instanceName, hostname, version](Task& task) {
-            LOGI("mDNS: initializing");
+            LOGTI("mdns", "initializing");
             WiFiConnection connection(wifi);
 
             ESP_ERROR_CHECK(mdns_init());
 
             mdns_hostname_set(hostname.c_str());
             mdns_instance_name_set(instanceName.c_str());
-            LOGD("mDNS: Advertising service %s on %s.local, version: %s",
+            LOGTD("mdns", "Advertising service %s on %s.local, version: %s",
                 instanceName.c_str(), hostname.c_str(), version.c_str());
             mdns_service_add(instanceName.c_str(), "_farmhub", "_tcp", 80, nullptr, 0);
             mdns_txt_item_t txt[] = {
                 { "version", version.c_str() },
             };
             mdns_service_txt_set("_farmhub", "_tcp", txt, 1);
-            LOGI("mDNS: configured");
+            LOGTI("mdns", "configured");
 
             mdnsReady.set();
         });
@@ -68,17 +68,17 @@ private:
         if (loadFromCache) {
             if (nvs.get(cacheKey, record)) {
                 if (record.validate()) {
-                    LOGD("mDNS: found %s in NVS cache: %s",
+                    LOGTD("mdns", "found %s in NVS cache: %s",
                         cacheKey.c_str(), record.hostname.c_str());
                     return true;
                 } else {
-                    LOGD("mDNS: invalid record in NVS cache for %s, removing",
+                    LOGTD("mdns", "invalid record in NVS cache for %s, removing",
                         cacheKey.c_str());
                     nvs.remove(cacheKey);
                 }
             }
         } else {
-            LOGD("mDNS: removing untrusted record for %s from NVS cache",
+            LOGTD("mdns", "removing untrusted record for %s from NVS cache",
                 cacheKey.c_str());
             nvs.remove(cacheKey);
         }
@@ -89,12 +89,12 @@ private:
         mdns_result_t* results = nullptr;
         esp_err_t err = mdns_query_ptr(String("_" + serviceName).c_str(), String("_" + port).c_str(), timeout.count(), 1, &results);
         if (err) {
-            LOGE("mDNS: query failed for %s.%s: %d",
+            LOGTE("mdns", "query failed for %s.%s: %d",
                 serviceName.c_str(), port.c_str(), err);
             return false;
         }
         if (results == nullptr) {
-            LOGI("mDNS: no results found for %s.%s",
+            LOGTI("mdns", "no results found for %s.%s",
                 serviceName.c_str(), port.c_str());
             return false;
         }

--- a/main/kernel/drivers/RtcDriver.hpp
+++ b/main/kernel/drivers/RtcDriver.hpp
@@ -43,7 +43,7 @@ public:
         , rtcInSync(rtcInSync) {
 
         if (isTimeSet()) {
-            LOGI("RTC: time is already set");
+            LOGTI("rtc", "time is already set");
             rtcInSync.set();
         }
 
@@ -55,7 +55,7 @@ public:
                         trustMdnsCache = true;
                     } else {
                         // Attempt a retry, but with mDNS cache disabled
-                        LOGE("RTC: NTP update failed, retrying in 10 seconds with mDNS cache disabled");
+                        LOGTE("rtc", "NTP update failed, retrying in 10 seconds with mDNS cache disabled");
                         trustMdnsCache = false;
                         task.delay(10s);
                         continue;
@@ -89,24 +89,24 @@ private:
         ESP_ERROR_CHECK(esp_netif_sntp_init(&config));
 
 #ifdef WOKWI
-        LOGI("RTC: using default NTP server for Wokwi");
+        LOGTI("rtc", "using default NTP server for Wokwi");
 #else
         // TODO Check this
         if (ntpConfig.host.get().length() > 0) {
-            LOGD("RTC: using NTP server %s from configuration",
+            LOGTD("rtc", "using NTP server %s from configuration",
                 ntpConfig.host.get().c_str());
             esp_sntp_setservername(0, ntpConfig.host.get().c_str());
         } else {
             MdnsRecord ntpServer;
             if (mdns.lookupService("ntp", "udp", ntpServer, trustMdnsCache)) {
-                LOGD("RTC: using NTP server %s:%d (%s) from mDNS",
+                LOGTD("rtc", "using NTP server %s:%d (%s) from mDNS",
                     ntpServer.hostname.c_str(),
                     ntpServer.port,
                     ntpServer.ip.toString().c_str());
                 auto serverIp = convertIp4(ntpServer.ip);
                 esp_sntp_setserver(0, &serverIp);
             } else {
-                LOGD("RTC: no NTP server configured, using default");
+                LOGTD("rtc", "no NTP server configured, using default");
             }
         }
 #endif
@@ -121,11 +121,11 @@ private:
         if (ret == ESP_OK || ret == ESP_ERR_NOT_FINISHED) {
             rtcInSync.set();
             success = true;
-            LOGD("RTC: sync finished successfully");
+            LOGTD("rtc", "sync finished successfully");
         } else if (ret == ESP_ERR_TIMEOUT) {
-            LOGD("RTC: waiting for time sync timed out");
+            LOGTD("rtc", "waiting for time sync timed out");
         } else {
-            LOGD("RTC: waiting for time sync returned 0x%x", ret);
+            LOGTD("rtc", "waiting for time sync returned 0x%x", ret);
         }
 
         esp_netif_sntp_deinit();

--- a/main/kernel/drivers/WiFiDriver.hpp
+++ b/main/kernel/drivers/WiFiDriver.hpp
@@ -26,7 +26,7 @@ public:
         , configPortalRunning(configPortalRunning)
         , hostname(hostname)
         , powerSaveMode(powerSaveMode) {
-        LOGD("WiFi: initializing");
+        LOGTD("wifi", "initializing");
 
         // Initialize TCP/IP adapter and event loop
         ESP_ERROR_CHECK(esp_netif_init());
@@ -80,15 +80,15 @@ private:
     void onWiFiEvent(int32_t eventId, void* eventData) {
         switch (eventId) {
             case WIFI_EVENT_STA_START: {
-                LOGD("WiFi: Started");
+                LOGTD("wifi", "Started");
                 esp_err_t err = esp_wifi_connect();
                 if (err != ESP_OK) {
-                    LOGD("WiFi: Failed to start connecting: %s", esp_err_to_name(err));
+                    LOGTD("wifi", "Failed to start connecting: %s", esp_err_to_name(err));
                 }
                 break;
             }
             case WIFI_EVENT_STA_STOP: {
-                LOGD("WiFi: Stopped");
+                LOGTD("wifi", "Stopped");
                 break;
             }
             case WIFI_EVENT_STA_CONNECTED: {
@@ -98,7 +98,7 @@ private:
                     Lock lock(metadataMutex);
                     ssid = newSsid;
                 }
-                LOGD("WiFi: Connected to the AP %s",
+                LOGTD("wifi", "Connected to the AP %s",
                     newSsid.c_str());
                 break;
             }
@@ -111,16 +111,16 @@ private:
                     ssid.reset();
                 }
                 eventQueue.offer(WiFiEvent::DISCONNECTED);
-                LOGD("WiFi: Disconnected from the AP %s, reason: %d",
+                LOGTD("wifi", "Disconnected from the AP %s, reason: %d",
                     String(event->ssid, event->ssid_len).c_str(), event->reason);
                 break;
             }
             case WIFI_EVENT_AP_STACONNECTED: {
-                LOGI("WiFi: SoftAP transport connected");
+                LOGTI("wifi", "SoftAP transport connected");
                 break;
             }
             case WIFI_EVENT_AP_STADISCONNECTED: {
-                LOGI("WiFi: SoftAP transport disconnected");
+                LOGTI("wifi", "SoftAP transport disconnected");
                 break;
             }
         }
@@ -137,7 +137,7 @@ private:
                     ip = event->ip_info.ip;
                 }
                 eventQueue.offer(WiFiEvent::CONNECTED);
-                LOGD("WiFi: Got IP - " IPSTR, IP2STR(&event->ip_info.ip));
+                LOGTD("wifi", "Got IP - " IPSTR, IP2STR(&event->ip_info.ip));
                 break;
             }
             case IP_EVENT_STA_LOST_IP: {
@@ -147,7 +147,7 @@ private:
                     ip.reset();
                 }
                 eventQueue.offer(WiFiEvent::DISCONNECTED);
-                LOGD("WiFi: Lost IP");
+                LOGTD("wifi", "Lost IP");
                 break;
             }
         }
@@ -156,7 +156,7 @@ private:
     void onWiFiProvEvent(int32_t eventId, void* eventData) {
         switch (eventId) {
             case WIFI_PROV_START: {
-                LOGD("WiFi: provisioning started");
+                LOGTD("wifi", "provisioning started");
                 // Do not turn WiFi off until provisioning finishes
                 acquire();
                 break;
@@ -169,7 +169,7 @@ private:
             }
             case WIFI_PROV_CRED_FAIL: {
                 auto* reason = static_cast<wifi_prov_sta_fail_reason_t*>(eventData);
-                LOGD("WiFi: provisioning failed because %s",
+                LOGTD("wifi", "provisioning failed because %s",
                     *reason == WIFI_PROV_STA_AUTH_ERROR
                         ? "authentication failed"
                         : "AP not found");
@@ -177,11 +177,11 @@ private:
                 break;
             }
             case WIFI_PROV_CRED_SUCCESS: {
-                LOGD("WiFi: provisioning successful");
+                LOGTD("wifi", "provisioning successful");
                 break;
             }
             case WIFI_PROV_END: {
-                LOGD("WiFi: provisioning finished");
+                LOGTD("wifi", "provisioning finished");
                 wifi_prov_mgr_deinit();
                 configPortalRunning.clear();
                 networkConnecting.clear();
@@ -216,18 +216,18 @@ private:
                 networkRequested.set();
                 if (!connected) {
                     if (networkConnecting.isSet()) {
-                        LOGV("WiFi: Already connecting");
+                        LOGTV("wifi", "Already connecting");
                     } else if (configPortalRunning.isSet()) {
-                        LOGV("WiFi: Provisioning already running");
+                        LOGTV("wifi", "Provisioning already running");
                     } else {
-                        LOGV("WiFi: Connecting for first client");
+                        LOGTV("wifi", "Connecting for first client");
                         connect();
                     }
                 }
             } else {
                 networkRequested.clear();
                 if (connected && powerSaveMode) {
-                    LOGV("WiFi: No more clients, disconnecting");
+                    LOGTV("wifi", "No more clients, disconnecting");
                     disconnect();
                 }
             }
@@ -237,7 +237,7 @@ private:
     void connect() {
         networkConnecting.set();
 #ifdef WOKWI
-        LOGD("WiFi: Skipping provisioning on Wokwi");
+        LOGTD("wifi", "Skipping provisioning on Wokwi");
         wifi_config_t wifiConfig = {
             .sta = {
                 .ssid = "Wokwi-GUEST",
@@ -252,11 +252,11 @@ private:
         if (provisioned) {
             wifi_config_t wifiConfig;
             ESP_ERROR_CHECK(esp_wifi_get_config(WIFI_IF_STA, &wifiConfig));
-            LOGD("WiFi: Connecting using stored credentials to %s (password '%s')",
+            LOGTD("wifi", "Connecting using stored credentials to %s (password '%s')",
                 wifiConfig.sta.ssid, wifiConfig.sta.password);
             startStation(wifiConfig);
         } else {
-            LOGD("WiFi: No stored credentials, starting provisioning");
+            LOGTD("wifi", "No stored credentials, starting provisioning");
             configPortalRunning.set();
             startProvisioning();
         }
@@ -293,7 +293,7 @@ private:
         esp_wifi_get_mac(WIFI_IF_STA, mac);
         snprintf(serviceName, sizeof(serviceName), "%s%02X%02X%02X",
             ssid_prefix, mac[3], mac[4], mac[5]);
-        LOGD("WiFi: Starting provisioning service '%s'",
+        LOGTD("wifi", "Starting provisioning service '%s'",
             serviceName);
 
         ESP_ERROR_CHECK(wifi_prov_mgr_start_provisioning(WIFI_PROV_SECURITY_1, pop, serviceName, serviceKey));
@@ -307,7 +307,7 @@ private:
 
     void disconnect() {
         networkReady.clear();
-        LOGD("WiFi: Disconnecting");
+        LOGTD("wifi", "Disconnecting");
         ESP_ERROR_CHECK(esp_wifi_disconnect());
         ESP_ERROR_CHECK(esp_wifi_stop());
     }

--- a/main/kernel/mqtt/MqttRoot.hpp
+++ b/main/kernel/mqtt/MqttRoot.hpp
@@ -43,7 +43,7 @@ public:
             // Clear topic and wait for it to be cleared
             auto clearStatus = mqtt.clear(fullTopic(suffix), Retention::Retain, QoS::ExactlyOnce, std::chrono::seconds { 5 }, MQTT_ALERT_AFTER_INCOMING);
             if (clearStatus != PublishStatus::Success) {
-                LOGE("MQTT: Failed to clear retained command topic '%s', status: %d",
+                LOGTE("mqtt", "Failed to clear retained command topic '%s', status: %d",
                     suffix.c_str(), static_cast<int>(clearStatus));
             }
 


### PR DESCRIPTION
This introduces sub-tags like `farmhub:mqtt` etc. that can be configured separately.

It also allows the `wifi` tag to be observed, which was not possible before, because those events are reported in a weird way via multiple `vprintf()` calls. Now we stitch together these messages as best as we can.