### PR TITLE
Fix device staying online indefinitely

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -456,7 +456,7 @@ public:
                 json["peripherals"].to<JsonArray>().set(peripheralsInitJson);
                 json["sleepWhenIdle"] = kernel.sleepManager.sleepWhenIdle;
             },
-            Retention::NoRetain, QoS::AtLeastOnce, ticks::max());
+            Retention::NoRetain, QoS::AtLeastOnce, 5s);
 
         Task::loop("telemetry", 8192, [this](Task& task) {
             publishTelemetry();


### PR DESCRIPTION
The `init` message had an "infinite" timeout, keeping the MQTT / WiFi connection up forever. This is now fixed.