### PR TITLE
Report WiFi uptime

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -97,8 +97,9 @@ namespace farmhub::devices {
 #ifdef FARMHUB_DEBUG
 class ConsolePrinter {
 public:
-    ConsolePrinter(const shared_ptr<BatteryDriver> battery)
-        : battery(battery) {
+    ConsolePrinter(const shared_ptr<BatteryDriver> battery, WiFiDriver& wifi)
+        : battery(battery)
+        , wifi(wifi) {
         status.reserve(256);
         Task::loop("console", 3072, 1, [this](Task& task) {
             printStatus();
@@ -123,6 +124,9 @@ private:
 
         status.concat(", WIFI: ");
         status.concat(wifiStatus());
+        status.concat(" (up \033[33m");
+        status.concat(String(float(wifi.getUptime().count()) / 1000.0f, 1));
+        status.concat("\033[0m s)");
 
         status.concat(", uptime: \033[33m");
         status.concat(String(float(millis()) / 1000.0f, 1));
@@ -201,6 +205,7 @@ private:
     int counter;
     String status;
     const std::shared_ptr<BatteryDriver> battery;
+    WiFiDriver& wifi;
 };
 #endif
 
@@ -272,7 +277,7 @@ public:
 
 private:
 #ifdef FARMHUB_DEBUG
-    ConsolePrinter consolePrinter { battery };
+    ConsolePrinter consolePrinter { battery, kernel.wifi };
 #endif
 
     void checkBatteryVoltage(Task& task) {

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -216,6 +216,20 @@ public:
     }
 };
 
+class WiFiTelemetryProvider : public TelemetryProvider {
+public:
+    WiFiTelemetryProvider(WiFiDriver& wifi)
+        : wifi(wifi) {
+    }
+
+    void populateTelemetry(JsonObject& json) override {
+        json["uptime"] = wifi.getUptime().count();
+    }
+
+private:
+    WiFiDriver& wifi;
+};
+
 class MqttTelemetryPublisher : public TelemetryPublisher {
 public:
     MqttTelemetryPublisher(shared_ptr<MqttRoot> mqttRoot, TelemetryCollector& telemetryCollector)
@@ -370,6 +384,8 @@ public:
         } else {
             LOGI("No battery configured");
         }
+
+        deviceTelemetryCollector.registerProvider("wifi", std::make_shared<WiFiTelemetryProvider>(kernel.wifi));
 
 #if defined(FARMHUB_DEBUG) || defined(FARMHUB_REPORT_MEMORY)
         deviceTelemetryCollector.registerProvider("memory", std::make_shared<MemoryTelemetryProvider>());

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -147,6 +147,8 @@ private:
         }
 
         printf("\033[1G\033[0K%s", status.c_str());
+        fflush(stdout);
+        fsync(fileno(stdout));
     }
 
     static const char* wifiStatus() {

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -309,7 +309,7 @@ private:
     }
 
     MovingAverage<double> batteryVoltage { 5 };
-    std::list<function<void()>> shutdownListeners;
+    std::list<std::function<void()>> shutdownListeners;
 
     /**
      * @brief Time to wait between battery checks.

--- a/main/kernel/BootClock.hpp
+++ b/main/kernel/BootClock.hpp
@@ -3,8 +3,6 @@
 #include <chrono>
 #include <esp_timer.h>
 
-using namespace std;
-
 namespace farmhub::kernel {
 
 /**
@@ -13,10 +11,10 @@ namespace farmhub::kernel {
  *  Time returned has the property of only increasing at a uniform rate.
  */
 struct boot_clock {
-    typedef chrono::microseconds duration;
+    typedef std::chrono::microseconds duration;
     typedef duration::rep rep;
     typedef duration::period period;
-    typedef chrono::time_point<boot_clock, duration> time_point;
+    typedef std::chrono::time_point<boot_clock, duration> time_point;
 
     static constexpr bool is_steady = true;
 

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -141,8 +141,6 @@ private:
 #endif
         String payload;
         serializeJson(json, payload);
-        // Stay alert until the message is sent
-        extendAlert = std::max(duration_cast<milliseconds>(timeout), extendAlert);
         return executeAndAwait(timeout, [&](TaskHandle_t waitingTask) {
             return outgoingQueue.offerIn(MQTT_QUEUE_TIMEOUT, OutgoingMessage { topic, payload, retain, qos, waitingTask, log, extendAlert });
         });


### PR DESCRIPTION
WiFi uptime is now reported on the debug console and in the device telemetry, like so:

```jsonc
{
  "uptime": 244400,
  "battery": {
    "voltage": 3.80664
  },
  "memory": {
    "free-heap": 203012
  },
  "wifi": {
    "uptime": 18531  // <-- this
  }
}
```