### PR TITLE
Fix MQTT message publishing deadlock

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -22,24 +22,16 @@ idf_component_register(
     EMBED_TXTFILES "${CMAKE_SOURCE_DIR}/partitions.csv"
 )
 
-add_compile_definitions("${UD_GEN}")
-add_compile_definitions(FARMHUB_REPORT_MEMORY)
+component_compile_definitions("${UD_GEN}")
+component_compile_definitions(FARMHUB_REPORT_MEMORY)
 
 if(UD_DEBUG)
-    add_compile_definitions(FARMHUB_DEBUG)
-    add_compile_definitions(DUMP_MQTT)
+    component_compile_definitions(FARMHUB_DEBUG)
+    component_compile_definitions(DUMP_MQTT)
 else()
-    add_compile_options(-O2)
+    add_compile_options("-O2")
 endif()
 
 if(WOKWI)
-    add_compile_definitions(WOKWI)
+    component_compile_definitions(WOKWI)
 endif()
-
-# Set Git version
-execute_process(
-    COMMAND git describe --tags --dirty
-    OUTPUT_VARIABLE FARMHUB_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-add_compile_definitions(FARMHUB_VERSION="${FARMHUB_VERSION}")

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -119,7 +119,7 @@ private:
         status.concat("] ");
 
         status.concat("\033[33m");
-        status.concat(FARMHUB_VERSION);
+        status.concat(farmhubVersion);
         status.concat("\033[0m");
 
         status.concat(", WIFI: ");
@@ -272,7 +272,7 @@ public:
         LOGD("  | |__ __ _ _ __ _ __ ___ | |__| |_   _| |__");
         LOGD("  |  __/ _` | '__| '_ ` _ \\|  __  | | | | '_ \\");
         LOGD("  | | | (_| | |  | | | | | | |  | | |_| | |_) |");
-        LOGD("  |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ " FARMHUB_VERSION);
+        LOGD("  |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s", farmhubVersion);
         LOGD("  ");
     }
 

--- a/main/kernel/Concurrent.hpp
+++ b/main/kernel/Concurrent.hpp
@@ -9,6 +9,7 @@
 #include <freertos/FreeRTOS.h>
 
 #include <kernel/Time.hpp>
+#include <kernel/BootClock.hpp>
 
 using namespace std::chrono;
 
@@ -80,6 +81,34 @@ public:
                 break;
             }
             count++;
+        }
+        return count;
+    }
+
+    /**
+     * @brief Wait for the first item to appear within the given timeout,
+     * then drain any items remaining in the queue.
+     */
+    size_t drainIn(ticks timeout, MessageHandler handler) {
+        return drainIn(SIZE_MAX, timeout, handler);
+    }
+
+    /**
+     * @brief Wait for the first item to appear within the given timeout,
+     * then drain no more than `maxItems` items remaining in the queue.
+     */
+    size_t drainIn(size_t maxItems, ticks timeout, MessageHandler handler) {
+        size_t count = 0;
+        ticks nextTimeout = timeout;
+        while (true) {
+            if (count >= maxItems) {
+                break;
+            }
+            if (!pollIn(nextTimeout, handler)) {
+                break;
+            }
+            count++;
+            nextTimeout = ticks::zero();
         }
         return count;
     }

--- a/main/kernel/Console.hpp
+++ b/main/kernel/Console.hpp
@@ -46,18 +46,21 @@ private:
             return 0;
         }
 
+        String assembledMessage;
         {
             std::lock_guard<std::mutex> lock(partialMessageMutex);
             if (message.charAt(message.length() - 1) != '\n') {
                 partialMessage += message;
                 return 0;
             } else if (!partialMessage.isEmpty()) {
-                String fullMessage = partialMessage + message;
+                assembledMessage = partialMessage + message;
                 partialMessage.clear();
-                return processLogLine(fullMessage);
-            } else {
-                return processLogLine(message);
             }
+        }
+        if (assembledMessage.isEmpty()) {
+            return processLogLine(message);
+        } else {
+            return processLogLine(assembledMessage);
         }
     }
 

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -63,7 +63,7 @@ template <typename TDeviceConfiguration>
 class Kernel {
 public:
     Kernel(TDeviceConfiguration& deviceConfig, MqttDriver::Config& mqttConfig, LedDriver& statusLed)
-        : version(FARMHUB_VERSION)
+        : version(farmhubVersion)
         , deviceConfig(deviceConfig)
         , mqttConfig(mqttConfig)
         , statusLed(statusLed) {
@@ -227,7 +227,7 @@ private:
         }
 
         LOGI("Updating from version %s via URL %s",
-            FARMHUB_VERSION, url.c_str());
+            farmhubVersion, url.c_str());
 
         LOGD("Waiting for network...");
         WiFiConnection connection(wifi, WiFiConnection::Mode::NoAwait);

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -245,8 +245,7 @@ private:
             }
 
             // LOGTV("mqtt", "Waiting for outgoing event for %lld ms", duration_cast<milliseconds>(timeout).count());
-            outgoingQueue.pollIn(duration_cast<ticks>(timeout), [&](const auto& event) {
-                LOGTV("mqtt", "Processing outgoing event");
+            outgoingQueue.drainIn(duration_cast<ticks>(timeout), [&](const auto& event) {
                 ensureConnected(task);
 
                 std::visit(

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -253,7 +253,7 @@ private:
                     [&](auto&& arg) {
                         using T = std::decay_t<decltype(arg)>;
                         if constexpr (std::is_same_v<T, OutgoingMessage>) {
-                            LOGTV("mqtt", "Processing outgoing message: %s",
+                            LOGTV("mqtt", "Processing outgoing message to %s",
                                 arg.topic.c_str());
                             processOutgoingMessage(arg);
                             alertUntil = std::max(alertUntil, system_clock::now() + arg.extendAlert);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -6,6 +6,10 @@
 #include <chrono>
 #include <string>
 
+#include <esp_app_desc.h>
+
+static const char* const farmhubVersion = esp_app_get_description()->version;
+
 #include <kernel/Log.hpp>
 
 #ifdef CONFIG_HEAP_TRACING


### PR DESCRIPTION
Occasionally we got into a deadlock when publishing to MQTT from multiple tasks (typically the `"init"` message got in conflict with publishing an `INFO` log message).

This should not be a problem anymore.