### PR TITLE
Do not stop WiFi while provisioning

### DIFF
--- a/main/kernel/drivers/MdnsDriver.hpp
+++ b/main/kernel/drivers/MdnsDriver.hpp
@@ -103,7 +103,9 @@ private:
         if (result.hostname != nullptr) {
             record.hostname = result.hostname;
         }
-        record.ip = IPAddress(result.addr->addr.u_addr.ip4.addr);
+        if (result.addr != nullptr) {
+            record.ip = IPAddress(result.addr->addr.u_addr.ip4.addr);
+        }
         record.port = result.port;
         mdns_query_results_free(results);
 

--- a/main/kernel/drivers/SwitchManager.hpp
+++ b/main/kernel/drivers/SwitchManager.hpp
@@ -35,7 +35,7 @@ static void handleSwitchInterrupt(void* arg);
 class SwitchManager {
 public:
     SwitchManager() {
-        Task::loop("switch-manager", 1536, [this](Task& task) {
+        Task::loop("switch-manager", 3072, [this](Task& task) {
             SwitchStateChange stateChange = switchStateInterrupts.take();
             auto state = stateChange.switchState;
             auto engaged = stateChange.engaged;


### PR DESCRIPTION
Fixes WiFi stopping during provisioning. Also increased back stack size for `switch-manager` and fixed a problem about mDNS crashing if no IP is returned.