### PR TITLE
Stop using std::format()

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -13,6 +13,7 @@
 #include <kernel/Concurrent.hpp>
 #include <kernel/Console.hpp>
 #include <kernel/Kernel.hpp>
+#include <kernel/Strings.hpp>
 #include <kernel/Task.hpp>
 #include <kernel/drivers/RtcDriver.hpp>
 #include <kernel/mqtt/MqttDriver.hpp>
@@ -112,16 +113,16 @@ private:
 
         counter = (counter + 1) % spinnerLength;
         status.clear();
-        status += std::format("[{}] ", spinner[counter]);
-        status += std::format("\033[33m{}\033[0m", farmhubVersion);
-        status += std::format(", uptime: \033[33m{:.2f}\033[0m s", uptime.count() / 1000.0);
-        status += std::format(", WIFI: {} (up \033[33m{:.1f}\033[0m s)", wifiStatus(), wifi.getUptime().count() / 1000.0);
-        status += std::format(", RTC \033[33m{}\033[0m", RtcDriver::isTimeSet() ? "OK" : "UNSYNCED");
-        status += std::format(", heap \033[33m{:.2f}\033[0m kB", heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0);
-        status += std::format(", CPU: \033[33m{}\033[0m MHz", esp_clk_cpu_freq() / 1000000);
+        status += "[" + std::string(1, spinner[counter]) + "] ";
+        status += "\033[33m" + std::string(farmhubVersion) + "\033[0m";
+        status += ", uptime: \033[33m" + toStringWithPrecision(uptime.count() / 1000.0f, 1) + "\033[0m s";
+        status += ", WIFI: " + std::string(wifiStatus()) + " (up \033[33m" + toStringWithPrecision(wifi.getUptime().count() / 1000.0f, 1) + "\033[0m s)";
+        status += ", RTC \033[33m" + std::string(RtcDriver::isTimeSet() ? "OK" : "UNSYNCED") + "\033[0m";
+        status += ", heap \033[33m" + toStringWithPrecision(heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0f, 2) + "\033[0m kB";
+        status += ", CPU: \033[33m" + std::to_string(esp_clk_cpu_freq() / 1000000) + "\033[0m MHz";
 
         if (battery != nullptr) {
-            status += std::format(", battery: \033[33m{:.2f}\033[0m V", battery->getVoltage());
+            status += ", battery: \033[33m" + toStringWithPrecision(battery->getVoltage(), 2) + "\033[0m V";
         }
 
         printf("\033[1G\033[0K%s", status.c_str());

--- a/main/kernel/I2CManager.hpp
+++ b/main/kernel/I2CManager.hpp
@@ -6,6 +6,7 @@
 #include <i2cdev.h>
 
 #include <kernel/Pin.hpp>
+#include <kernel/Strings.hpp>
 
 namespace farmhub::kernel {
 
@@ -22,7 +23,7 @@ public:
     InternalPinPtr scl;
 
     std::string toString() const {
-        return std::format("I2C address: 0x{:#x}, SDA: {}, SCL: {}", address, sda->getName(), scl->getName());
+        return "I2C address: 0x" + toHexString(address) + ", SDA: " + sda->getName() + ", SCL: " + scl->getName();
     }
 };
 
@@ -124,7 +125,7 @@ public:
         // esp_err_t err = device->probeRead();
         // if (err != ESP_OK) {
         //     throw std::runtime_error(
-        //         std::format("Failed to communicate with I2C device {} at address 0x{:#x}: {}", name, address, esp_err_to_name(err)).c_str());
+        //         "Failed to communicate with I2C device " + name + " at address 0x" + std::to_string(address) + ": " + esp_err_to_name(err);
         // }
         return device;
     }

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -268,7 +268,7 @@ private:
         } else {
             LOGE("Update failed (%s), continuing with regular boot",
                 esp_err_to_name(ret));
-            return std::format("Firmware upgrade failed: {}", esp_err_to_name(ret));
+            return std::string("Firmware upgrade failed: ") + esp_err_to_name(ret);
         }
     }    // namespace farmhub::kernel
 

--- a/main/kernel/Pin.hpp
+++ b/main/kernel/Pin.hpp
@@ -93,7 +93,7 @@ public:
     static InternalPinPtr byGpio(gpio_num_t pin) {
         auto it = INTERNAL_BY_GPIO.find(pin);
         if (it == INTERNAL_BY_GPIO.end()) {
-            std::string name = std::format("GPIO_NUM_{}", static_cast<int>(pin));
+            std::string name = "GPIO_NUM_" + std::to_string(static_cast<int>(pin));
             return registerPin(name, pin);
         } else {
             return it->second;

--- a/main/kernel/Strings.hpp
+++ b/main/kernel/Strings.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <stdint.h>
+
+namespace farmhub::kernel {
+
+static constexpr const char* DIGITS = "0123456789abcdef";
+
+std::string toHexString(uint64_t value) {
+    char buffer[17] = {0};
+
+    for (int i = 15; i >= 0; --i) {
+        buffer[i] = DIGITS[value & 0xF];
+        value >>= 4;
+    }
+
+    const char* start = buffer;
+    while (*start == '0' && *(start + 1) != '\0') {
+        ++start;
+    }
+
+    return std::string(start);
+}
+
+std::string toStringWithPrecision(float value, int precision) {
+    char buffer[32];
+    std::snprintf(buffer, sizeof(buffer), "%.*f", precision, value);
+    return std::string(buffer);
+}
+
+}    // namespace farmhub::kernel

--- a/main/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/main/peripherals/fence/ElectricFenceMonitor.hpp
@@ -53,7 +53,7 @@ public:
         for (auto& pinConfig : config.pins.get()) {
             if (pinsDescription.length() > 0)
                 pinsDescription += ", ";
-            pinsDescription += std::format("{}={}V", pinConfig.pin->getName(), pinConfig.voltage);
+            pinsDescription += pinConfig.pin->getName() + "=" + std::to_string(pinConfig.voltage) + "V";
         }
         LOGI("Initializing electric fence with pins %s", pinsDescription.c_str());
 

--- a/main/peripherals/multiplexer/Xl9535.hpp
+++ b/main/peripherals/multiplexer/Xl9535.hpp
@@ -115,7 +115,7 @@ public:
 
         // Create a pin for each bit in the pins mask
         for (int i = 0; i < 16; i++) {
-            std::string pinName = std::format("{}:{}", name, i);
+            std::string pinName = name + ":" + std::to_string(i);
             LOGV("Registering external pin %s",
                 pinName.c_str());
             auto pin = std::make_shared<Xl9535Pin>(pinName, component, i);

--- a/main/peripherals/valve/ValveComponent.hpp
+++ b/main/peripherals/valve/ValveComponent.hpp
@@ -106,7 +106,7 @@ public:
     }
 
     std::string describe() const override {
-        return std::format("normally closed with switch duration {} ms and hold duty {}%", switchDuration.count(), holdDuty * 100);
+        return "normally closed with switch duration " + std::to_string(switchDuration.count()) + " ms and hold duty " + std::to_string(holdDuty * 100) + "%";
     }
 };
 
@@ -130,7 +130,7 @@ public:
     }
 
     std::string describe() const override {
-        return std::format("normally open with switch duration {} ms and hold duty {}%", switchDuration.count(), holdDuty * 100);
+        return "normally open with switch duration " + std::to_string(switchDuration.count()) + " ms and hold duty " + std::to_string(holdDuty * 100) + "%";
     }
 };
 
@@ -160,7 +160,7 @@ public:
     }
 
     std::string describe() const override {
-        return std::format("latching with switch duration {} ms and switch duty {}%", switchDuration.count(), switchDuty * 100);
+        return "latching with switch duration " + std::to_string(switchDuration.count()) + " ms and switch duty " + std::to_string(switchDuty * 100) + "%";
     }
 
 private:


### PR DESCRIPTION
This is a way to reduce binary size. We seem to be saving quite a lot actually: we are now down to 1237 kB for MK7 release artifact, and 1571 kB for MK7 debug.