### PR TITLE
Let device sleep when configured with a flow meter peripheral

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: esp-idf build
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.3.2
+          esp_idf_version: v5.3.1
           target: ${{ matrix.target }}
           command: idf.py build -DUD_GEN=${{ matrix.ud_gen }} -DUD_DEBUG=${{ matrix.ud_debug }}
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ See `FileCommands` for more information.
 
 ### Prerequisites
 
-- ESP-IDF v5.3.2 (see [installation instructions](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html))
+- ESP-IDF v5.3.1 (see [installation instructions](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html))
 
 We are using this version because it is the latest version that is compatible with Arduino-ESP32 3.1.0-rc-1.
 

--- a/idf-docker.py
+++ b/idf-docker.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 
 # Define the Docker image name
-IMAGE_NAME = "espressif/idf:v5.3.2"
+IMAGE_NAME = "espressif/idf:v5.3.1"
 
 # Get environment variables (or set defaults if not present)
 UD_GEN = os.getenv("UD_GEN")

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -4,4 +4,4 @@ dependencies:
   espressif/mdns: "1.4.2"
   bblanchon/arduinojson: "7.2.1"
   idf:
-    version: "5.3.2"
+    version: "5.3.1"


### PR DESCRIPTION
This reverts commit 0247a859fc44c84e9c657af53311e2e0d0c0e855.

We need to go back to ESP-IDF 5.3.1 until we can address the problem of sleeping with a PCNT unit enabled (flow meter).

Issue to try this again once the related problems are solved:

- #288