### PR TITLE
Include debug artifacts in release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,16 +47,16 @@ jobs:
 
       - name: Rename firmware artifact
         run: |
-          cp ${{ github.workspace }}/build/ugly-duckling.bin ugly-duckling-${{ matrix.environment }}.bin
+          cp build/ugly-duckling.bin ugly-duckling-${{ matrix.environment }}.bin
 
       - name: Create debug artifact
         run: |
           zip debug-${{ matrix.environment }}.zip \
-            ${{ github.workspace }}/build/project_description.json \
-            ${{ github.workspace }}/build/*.bin \
-            ${{ github.workspace }}/build/*.elf \
-            ${{ github.workspace }}/build/*.map \
-            ${{ github.workspace }}/build/config/sdkconfig.h
+            build/project_description.json \
+            build/*.bin \
+            build/*.elf \
+            build/*.map \
+            build/config/sdkconfig.h
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{ matrix.environment }}
+          name: ${{ matrix.environment }}
           path: |
             ugly-duckling-${{ matrix.environment }}.bin
             debug-${{ matrix.environment }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,25 @@ jobs:
           command: idf.py build -DUD_GEN=${{ matrix.ud_gen }} -DUD_DEBUG=${{ matrix.ud_debug }}
 
       - name: Rename firmware artifact
-        run: cp ${{ github.workspace }}/build/ugly-duckling.bin ugly-duckling-${{ matrix.environment }}.bin
+        run: |
+          cp ${{ github.workspace }}/build/ugly-duckling.bin ugly-duckling-${{ matrix.environment }}.bin
 
-      - name: Upload firmware artifact
+      - name: Create debug artifact
+        run: |
+          zip debug-${{ matrix.environment }}.zip \
+            ${{ github.workspace }}/build/project_description.json \
+            ${{ github.workspace }}/build/*.bin \
+            ${{ github.workspace }}/build/*.elf \
+            ${{ github.workspace }}/build/*.map \
+            ${{ github.workspace }}/build/config/sdkconfig.h
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: firmware-${{ matrix.environment }}
-          path: ugly-duckling-${{ matrix.environment }}.bin
+          path: |
+            ugly-duckling-${{ matrix.environment }}.bin
+            debug-${{ matrix.environment }}.zip
           if-no-files-found: error
 
   release:


### PR DESCRIPTION
This allows debugging released versions of the firmware and lets us make sense of backtraces from crash reports (see https://github.com/kivancsikert/ugly-duckling/pull/290).