### PR TITLE
Init WiFi and MQTT only once

### DIFF
--- a/data-templates/device-config-wokwi.json
+++ b/data-templates/device-config-wokwi.json
@@ -1,7 +1,7 @@
 {
   "id": "wokwi",
   "instance": "wokwi",
-  "location": "local",
+  "location": "bumblebee",
   "peripherals": [
   ],
   "sleepWhenIdle": true

--- a/data-templates/device-config-wokwi.json
+++ b/data-templates/device-config-wokwi.json
@@ -3,6 +3,18 @@
   "instance": "wokwi",
   "location": "bumblebee",
   "peripherals": [
+    {
+      "name": "flow-control-a",
+      "type": "flow-control",
+      "params": {
+        "valve": {
+          "motor": "a"
+        },
+        "flow-meter": {
+          "pin": "A1"
+        }
+      }
+    }
   ],
   "sleepWhenIdle": true
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,11 @@
 FILE(GLOB_RECURSE app_sources main.cpp **/*.cpp)
 
+idf_component_register(
+    SRCS ${app_sources}
+    INCLUDE_DIRS "."
+    EMBED_TXTFILES "${CMAKE_SOURCE_DIR}/partitions.csv"
+)
+
 if(NOT DEFINED WOKWI)
     set(WOKWI "$ENV{WOKWI}")
 endif()
@@ -10,12 +16,6 @@ set_property(DIRECTORY PROPERTY WOKWI_TRACKER "${WOKWI}")
 if(WOKWI)
     component_compile_definitions(WOKWI)
 endif()
-
-idf_component_register(
-    SRCS ${app_sources}
-    INCLUDE_DIRS "."
-    EMBED_TXTFILES "${CMAKE_SOURCE_DIR}/partitions.csv"
-)
 
 component_compile_definitions("${UD_GEN}")
 component_compile_definitions(FARMHUB_REPORT_MEMORY)

--- a/main/kernel/BootClock.hpp
+++ b/main/kernel/BootClock.hpp
@@ -22,7 +22,7 @@ struct boot_clock {
         return time_point(duration(esp_timer_get_time()));
     }
 
-    static time_point boot_time() noexcept {
+    static time_point zero() noexcept {
         return time_point(duration(0));
     }
 };

--- a/main/kernel/Console.hpp
+++ b/main/kernel/Console.hpp
@@ -84,6 +84,12 @@ private:
             case Level::Info:
                 count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_GREEN));
                 break;
+            case Level::Debug:
+                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_CYAN));
+                break;
+            case Level::Verbose:
+                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_BLUE));
+                break;
             default:
                 break;
         }

--- a/main/kernel/Log.hpp
+++ b/main/kernel/Log.hpp
@@ -46,6 +46,11 @@ void convertFromJson(JsonVariantConst src, Level& dst) {
 }
 
 static void initLogging() {
+#ifdef FARMHUB_DEBUG
+    // Reset ANSI colors
+    printf("\033[0m");
+#endif
+
     const char* logTags[] = {
         "farmhub",
         "farmhub:mdns",

--- a/main/kernel/drivers/WiFiDriver.hpp
+++ b/main/kernel/drivers/WiFiDriver.hpp
@@ -191,7 +191,7 @@ private:
         }
     }
 
-    inline void runLoop() {
+    void runLoop() {
         int clients = 0;
         bool connected = false;
         std::optional<time_point<boot_clock>> connectingSince;

--- a/main/kernel/drivers/WiFiDriver.hpp
+++ b/main/kernel/drivers/WiFiDriver.hpp
@@ -43,6 +43,10 @@ public:
         ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, &WiFiDriver::onEvent, this));
         ESP_ERROR_CHECK(esp_event_handler_register(WIFI_PROV_EVENT, ESP_EVENT_ANY_ID, &WiFiDriver::onEvent, this));
 
+        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+        ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+        ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_FLASH));
+
         Task::run("wifi-driver", 4096, [this](Task&) {
             runLoop();
         });
@@ -202,8 +206,8 @@ private:
                         if (networkRequested.isSet() && !configPortalRunning.isSet()) {
                             esp_err_t err = esp_wifi_connect();
                             if (err != ESP_OK) {
-                                LOGTD("wifi", "Failed to start connecting: %s", esp_err_to_name(err));
-                                ensureWifiDeinitialized();
+                                LOGTD("wifi", "Failed to start connecting: %s, stopping", esp_err_to_name(err));
+                                ensureWifiStopped();
                             }
                         }
                         break;
@@ -239,7 +243,7 @@ private:
 
                         LOGTI("wifi", "Connection timed out, retrying");
                         networkConnecting.clear();
-                        ensureWifiDeinitialized();
+                        ensureWifiStopped();
                     }
                     LOGTV("wifi", "Connecting for first client");
                     connectingSince = boot_clock::now();
@@ -256,7 +260,6 @@ private:
 
     void connect() {
         networkConnecting.set();
-        ensureWifiInitialized();
 
 #ifdef WOKWI
         LOGTD("wifi", "Skipping provisioning on Wokwi");
@@ -288,32 +291,9 @@ private:
     void disconnect() {
         if (powerSaveMode) {
             LOGTV("wifi", "No more clients, shutting down radio to conserve power");
-            ensureWifiDeinitialized();
+            ensureWifiStopped();
         } else {
             LOGTV("wifi", "No more clients, but staying online because not saving power");
-        }
-    }
-
-    void ensureWifiInitialized() {
-        if (!wifiInitialized) {
-            LOGTD("wifi", "Initializing WiFi");
-            wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-            ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-            ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_FLASH));
-            wifiUpSince = boot_clock::now();
-            wifiInitialized = true;
-        }
-    }
-
-    void ensureWifiDeinitialized() {
-        if (wifiInitialized) {
-            ensureWifiStopped();
-            auto currentUptime = currentWifiUptime();
-            wifiUptimeBefore += currentUptime;
-            wifiUpSince.reset();
-            LOGTD("wifi", "De-initializing WiFi (spent %lld ms initialized)", currentUptime.count());
-            ESP_ERROR_CHECK(esp_wifi_deinit());
-            wifiInitialized = false;
         }
     }
 
@@ -325,7 +305,7 @@ private:
     }
 
     void ensureWifiStationStarted(wifi_config_t& config) {
-        ensureWifiInitialized();
+        wifiUpSince = boot_clock::now();
         if (!stationStarted.isSet()) {
             if (powerSaveMode) {
                 auto listenInterval = 50;
@@ -351,6 +331,10 @@ private:
             LOGTD("wifi", "Stopping");
             ESP_ERROR_CHECK(esp_wifi_stop());
         }
+        auto currentUptime = currentWifiUptime();
+        wifiUptimeBefore += currentUptime;
+        wifiUpSince.reset();
+        LOGTD("wifi", "Stopping WiFi (was up %lld ms)", currentUptime.count());
     }
 
     void ensureWifiDisconnected() {
@@ -367,8 +351,6 @@ private:
     }
 
     void startProvisioning() {
-        ensureWifiInitialized();
-
         // Initialize provisioning manager
         wifi_prov_mgr_config_t config = {
             .scheme = wifi_prov_scheme_softap,


### PR DESCRIPTION
This simplifies how MQTT and WiFi are handled. The slight downside is that both services keep hold of their heap, but the large amounts of available heap was only temporary anyway, so it's not a big deal.

In return the code is quite a bit simpler and hopefully more robust, too.