### PR TITLE
Use watchdog to restart device if no telemetry is published

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -503,6 +503,10 @@ public:
 
         Task::loop("telemetry", 8192, [this](Task& task) {
             publishTelemetry();
+
+            // Signal that we are still alive
+            kernel.watchdog.restart();
+
             // TODO Configure these telemetry intervals
             // Publishing interval
             const auto interval = 1min;

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -17,6 +17,7 @@
 #include <kernel/I2CManager.hpp>
 #include <kernel/PowerManager.hpp>
 #include <kernel/StateManager.hpp>
+#include <kernel/Watchdog.hpp>
 #include <kernel/drivers/LedDriver.hpp>
 #include <kernel/drivers/MdnsDriver.hpp>
 #include <kernel/drivers/RtcDriver.hpp>
@@ -303,6 +304,14 @@ private:
     TDeviceConfiguration& deviceConfig;
 
 public:
+    // TODO Make this configurable
+    Watchdog watchdog { "watchdog", 5min, true, [](WatchdogState state) {
+                           if (state == WatchdogState::TimedOut) {
+                               LOGE("Watchdog timed out");
+                               esp_system_abort("Watchdog timed out");
+                           }
+                       } };
+
     PowerManager powerManager { deviceConfig.sleepWhenIdle.get() };
 
 private:

--- a/main/kernel/Watchdog.hpp
+++ b/main/kernel/Watchdog.hpp
@@ -20,12 +20,12 @@ class Watchdog {
 public:
     Watchdog(const String& name, const ticks timeout, bool startImmediately, WatchdogCallback callback)
         : timeout(timeout)
-        , callback(callback) {
-        timer = xTimerCreate(name.c_str(), timeout.count(), false, this, [](TimerHandle_t timer) {
+        , callback(callback)
+        , timer(xTimerCreate(name.c_str(), timeout.count(), false, this, [](TimerHandle_t timer) {
             LOGD("Watchdog '%s' timed out", pcTimerGetName(timer));
             auto watchdog = static_cast<Watchdog*>(pvTimerGetTimerID(timer));
             watchdog->callback(WatchdogState::TimedOut);
-        });
+        })) {
         if (!timer) {
             LOGE("Failed to create watchdog timer");
             esp_system_abort("Failed to create watchdog timer");
@@ -60,8 +60,7 @@ public:
 private:
     const ticks timeout;
     const WatchdogCallback callback;
-
-    TimerHandle_t timer = nullptr;
+    const TimerHandle_t timer;
 };
 
 }    // namespace farmhub::kernel

--- a/main/kernel/Watchdog.hpp
+++ b/main/kernel/Watchdog.hpp
@@ -2,8 +2,8 @@
 
 #include <functional>
 
-#include <kernel/Concurrent.hpp>
-#include <kernel/Task.hpp>
+#include <esp_check.h>
+
 #include <kernel/Time.hpp>
 
 namespace farmhub::kernel {
@@ -19,44 +19,49 @@ typedef std::function<void(WatchdogState)> WatchdogCallback;
 class Watchdog {
 public:
     Watchdog(const String& name, const ticks timeout, bool startImmediately, WatchdogCallback callback)
-        : name(name)
-        , timeout(timeout)
+        : timeout(timeout)
         , callback(callback) {
+        timer = xTimerCreate(name.c_str(), timeout.count(), false, this, [](TimerHandle_t timer) {
+            LOGD("Watchdog '%s' timed out", pcTimerGetName(timer));
+            auto watchdog = static_cast<Watchdog*>(pvTimerGetTimerID(timer));
+            watchdog->callback(WatchdogState::TimedOut);
+        });
+        if (!timer) {
+            LOGE("Failed to create watchdog timer");
+            esp_system_abort("Failed to create watchdog timer");
+        }
         if (startImmediately) {
             restart();
         }
     }
 
-    void restart() {
-        Lock lock(updateMutex);
-        cancel();
-        handle = Task::run(name, 3172, [this](Task& task) {
-            task.delayUntil(timeout);
-            Lock lock(updateMutex);
-            callback(WatchdogState::TimedOut);
-        });
-        callback(WatchdogState::Started);
-        LOGD("Watchdog started with a timeout of %.2f seconds",
-            duration_cast<milliseconds>(timeout).count() / 1000.0);
+    ~Watchdog() {
+        xTimerDelete(timer, 0);
     }
 
-    void cancel() {
-        Lock lock(updateMutex);
-        if (handle.isValid()) {
-            handle.abort();
-            callback(WatchdogState::Cancelled);
-            handle = TaskHandle();
-            LOGD("Watchdog cancelled");
+    bool restart() {
+        if (xTimerReset(timer, 0) != pdPASS) {
+            LOGE("Failed to reset watchdog timer '%s'", pcTimerGetName(timer));
+            return false;
         }
+        callback(WatchdogState::Started);
+        return true;
+    }
+
+    bool cancel() {
+        if (xTimerStop(timer, 0) != pdPASS) {
+            LOGE("Failed to stop watchdog timer '%s'", pcTimerGetName(timer));
+            return false;
+        }
+        callback(WatchdogState::Cancelled);
+        return true;
     }
 
 private:
-    const String name;
     const ticks timeout;
     const WatchdogCallback callback;
 
-    RecursiveMutex updateMutex;
-    TaskHandle handle;
+    TimerHandle_t timer = nullptr;
 };
 
 }    // namespace farmhub::kernel

--- a/main/kernel/Watchdog.hpp
+++ b/main/kernel/Watchdog.hpp
@@ -18,10 +18,13 @@ typedef std::function<void(WatchdogState)> WatchdogCallback;
 
 class Watchdog {
 public:
-    Watchdog(const String& name, const ticks timeout, WatchdogCallback callback)
+    Watchdog(const String& name, const ticks timeout, bool startImmediately, WatchdogCallback callback)
         : name(name)
         , timeout(timeout)
         , callback(callback) {
+        if (startImmediately) {
+            restart();
+        }
     }
 
     void restart() {

--- a/main/kernel/Watchdog.hpp
+++ b/main/kernel/Watchdog.hpp
@@ -10,7 +10,7 @@ namespace farmhub::kernel {
 
 enum class WatchdogState {
     Started,
-    Cacnelled,
+    Cancelled,
     TimedOut
 };
 
@@ -41,7 +41,7 @@ public:
         Lock lock(updateMutex);
         if (handle.isValid()) {
             handle.abort();
-            callback(WatchdogState::Cacnelled);
+            callback(WatchdogState::Cancelled);
             handle = TaskHandle();
             LOGD("Watchdog cancelled");
         }

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -112,7 +112,7 @@ public:
               SwitchMode::PullUp,
               [this](const Switch&) { updateState(); },
               [this](const Switch&, milliseconds) { updateState(); }))
-        , watchdog(name + ":watchdog", movementTimeout, [this](WatchdogState state) {
+        , watchdog(name + ":watchdog", movementTimeout, false, [this](WatchdogState state) {
             handleWatchdogEvent(state);
         })
         , publishTelemetry(publishTelemetry)

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -260,7 +260,7 @@ private:
                 LOGI("Watchdog started");
                 sleepLock.emplace(preventLightSleep);
                 break;
-            case WatchdogState::Cacnelled:
+            case WatchdogState::Cancelled:
                 LOGI("Watchdog cancelled");
                 sleepLock.reset();
                 break;


### PR DESCRIPTION
The assumption is that the device will publish telemetry every so often. If this doesn't happen for five minutes, then we consider something went horribly wrong, and restart.

This reworks the watchdog timer (also used in the chicken door) to a FreeRTOS timer. This should be mor lightweight than starting tasks.