### PR TITLE
Fix phantom-leak detection on flow-meter

### DIFF
--- a/main/kernel/Log.hpp
+++ b/main/kernel/Log.hpp
@@ -27,6 +27,7 @@ public:
     static constexpr const char* MDNS = "farmhub:mdns";
     static constexpr const char* MQTT = "farmhub:mqtt";
     static constexpr const char* NVS = "farmhub:nvs";
+    static constexpr const char* PCNT = "farmhub:pcnt";
     static constexpr const char* PM = "farmhub:pm";
     static constexpr const char* RTC = "farmhub:rtc";
     static constexpr const char* WIFI = "farmhub:wifi";
@@ -74,6 +75,7 @@ public:
             esp_log_level_set(tag, ESP_LOG_INFO);
 #endif
         }
+        esp_log_level_set(Tag::PCNT, ESP_LOG_VERBOSE);
     }
 
 private:
@@ -82,6 +84,7 @@ private:
         Tag::MDNS,
         Tag::MQTT,
         Tag::NVS,
+        Tag::PCNT,
         Tag::PM,
         Tag::RTC,
         Tag::WIFI,

--- a/main/kernel/Log.hpp
+++ b/main/kernel/Log.hpp
@@ -75,7 +75,6 @@ public:
             esp_log_level_set(tag, ESP_LOG_INFO);
 #endif
         }
-        esp_log_level_set(Tag::PCNT, ESP_LOG_VERBOSE);
     }
 
 private:

--- a/main/kernel/PcntManager.hpp
+++ b/main/kernel/PcntManager.hpp
@@ -12,21 +12,11 @@ namespace farmhub::kernel {
 //      See https://docs.espressif.com/projects/esp-idf/en/release-v4.2/esp32/api-reference/peripherals/ledc.html#ledc-high-and-low-speed-mode
 
 // TODO Limit number of channels available
-struct PcntUnit {
-    PcntUnit(pcnt_unit_handle_t unit, InternalPinPtr pin)
+struct PulseCounterUnit {
+    PulseCounterUnit(pcnt_unit_handle_t unit, InternalPinPtr pin)
         : unit(unit)
         , pin(pin) {
     }
-
-    PcntUnit()
-        : PcntUnit(nullptr, nullptr) {
-    }
-
-    PcntUnit(const PcntUnit& other)
-        : PcntUnit(other.unit, other.pin) {
-    }
-
-    PcntUnit& operator=(const PcntUnit& other) = default;
 
     int getCount() const {
         int count;
@@ -55,13 +45,13 @@ struct PcntUnit {
     }
 
 private:
-    pcnt_unit_handle_t unit;
-    InternalPinPtr pin;
+    const pcnt_unit_handle_t unit;
+    const InternalPinPtr pin;
 };
 
 class PcntManager {
 public:
-    PcntUnit registerUnit(InternalPinPtr pin, nanoseconds maxGlitchDuration = 1000ns) {
+    shared_ptr<PulseCounterUnit> registerUnit(InternalPinPtr pin, nanoseconds maxGlitchDuration = 1000ns) {
         pcnt_unit_config_t unitConfig = {
             .low_limit = std::numeric_limits<int16_t>::min(),
             .high_limit = std::numeric_limits<int16_t>::max(),
@@ -91,7 +81,7 @@ public:
 
         LOGTD(Tag::PCNT, "Registered PCNT unit on pin %s",
             pin->getName().c_str());
-        return PcntUnit(unit, pin);
+        return make_shared<PulseCounterUnit>(unit, pin);
     }
 };
 

--- a/main/kernel/PcntManager.hpp
+++ b/main/kernel/PcntManager.hpp
@@ -31,11 +31,15 @@ struct PcntUnit {
     int getCount() const {
         int count;
         pcnt_unit_get_count(unit, &count);
+        LOGTV(Tag::PCNT, "Counted %d pulses on pin %s",
+            count, pin->getName().c_str());
         return count;
     }
 
     void clear() {
         pcnt_unit_clear_count(unit);
+        LOGTV(Tag::PCNT, "Cleared counter on pin %s",
+            pin->getName().c_str());
     }
 
     int16_t getAndClearCount() {
@@ -85,7 +89,7 @@ public:
         ESP_ERROR_CHECK(pcnt_unit_clear_count(unit));
         ESP_ERROR_CHECK(pcnt_unit_start(unit));
 
-        LOGD("Registered PCNT unit on pin %s",
+        LOGTD(Tag::PCNT, "Registered PCNT unit on pin %s",
             pin->getName().c_str());
         return PcntUnit(unit, pin);
     }

--- a/main/kernel/PulseCounter.hpp
+++ b/main/kernel/PulseCounter.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <atomic>
+
+#include <driver/gpio.h>
+
+#include <kernel/Pin.hpp>
+
+#include <Arduino.h>
+
+namespace farmhub::kernel {
+
+/**
+ * Interrupt-based pulse-counter for low-frequency signals.
+ */
+class PulseCounter {
+public:
+    PulseCounter(InternalPinPtr pin)
+        : pin(pin) {
+        // Configure the GPIO pin as an input
+        gpio_config_t config = {
+            .pin_bit_mask = 1ULL << pin->getGpio(),
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE   ,
+            .intr_type = GPIO_INTR_POSEDGE,
+        };
+        gpio_config(&config);
+
+        // Install GPIO ISR service
+        gpio_install_isr_service(0);
+
+        // Attach the ISR handler to the GPIO pin
+        gpio_isr_handler_add(pin->getGpio(), interruptHandler, this);
+
+        LOGTD(Tag::PCNT, "Registered interrupt-based pulse counter unit on pin %s",
+            pin->getName().c_str());
+    }
+
+    uint32_t getCount() const {
+        uint32_t count = counter.load();
+        LOGTV(Tag::PCNT, "Counted %lu pulses on pin %s",
+            count, pin->getName().c_str());
+        return count;
+    }
+
+    uint32_t reset() {
+        uint32_t count = counter.exchange(0);
+        LOGTV(Tag::PCNT, "Counted %lu pulses and cleared on pin %s",
+            count, pin->getName().c_str());
+        return count;
+    }
+
+    PinPtr getPin() const {
+        return pin;
+    }
+
+private:
+    static void IRAM_ATTR interruptHandler(void *arg) {
+        auto self = static_cast<PulseCounter*>(arg);
+        self->counter++;
+    }
+
+    const InternalPinPtr pin;
+    std::atomic<uint32_t> counter { 0 };
+};
+
+}    // namespace farmhub::kernel

--- a/main/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/main/peripherals/fence/ElectricFenceMonitor.hpp
@@ -7,7 +7,7 @@
 
 #include <kernel/Component.hpp>
 #include <kernel/Concurrent.hpp>
-#include <kernel/PcntManager.hpp>
+#include <kernel/PulseCounter.hpp>
 #include <kernel/Telemetry.hpp>
 
 #include <peripherals/Peripheral.hpp>
@@ -47,7 +47,6 @@ public:
     ElectricFenceMonitorComponent(
         const String& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PcntManager& pcnt,
         const ElectricFenceMonitorDeviceConfig& config)
         : Component(name, mqttRoot) {
 
@@ -60,27 +59,23 @@ public:
         LOGI("Initializing electric fence with pins %s", pinsDescription.c_str());
 
         for (auto& pinConfig : config.pins.get()) {
-            auto unit = pcnt.registerUnit(pinConfig.pin, nanoseconds::zero());
+            auto unit = make_shared<PulseCounter>(pinConfig.pin);
             pins.emplace_back(pinConfig.voltage, unit);
         }
 
-        // TODO Use PCNT event callbacks instead?
         auto measurementFrequency = config.measurementFrequency.get();
         Task::loop(name, 3172, [this, measurementFrequency](Task& task) {
             uint16_t lastVoltage = 0;
             for (auto& pin : pins) {
-                int16_t count = pin.pcntUnit.getAndClearCount();
+                uint32_t count = pin.counter->reset();
 
                 if (count > 0) {
                     lastVoltage = max(pin.voltage, lastVoltage);
-                    LOGV("Counted %d pulses on pin %s (voltage: %dV)",
-                        count, pin.pcntUnit.getPin()->getName().c_str(), pin.voltage);
+                    LOGV("Counted %ld pulses on pin %s (voltage: %dV)",
+                        count, pin.counter->getPin()->getName().c_str(), pin.voltage);
                 }
             }
-            {
-                Lock lock(updateMutex);
-                this->lastVoltage = lastVoltage;
-            }
+            this->lastVoltage = lastVoltage;
             LOGV("Last voltage: %d",
                 lastVoltage);
             task.delayUntil(measurementFrequency);
@@ -88,17 +83,15 @@ public:
     }
 
     void populateTelemetry(JsonObject& json) override {
-        Lock lock(updateMutex);
-        json["voltage"] = lastVoltage;
+        json["voltage"] = lastVoltage.load();
     }
 
 private:
-    Mutex updateMutex;
-    uint16_t lastVoltage;
+    std::atomic<uint16_t> lastVoltage { 0 };
 
     struct FencePin {
         uint16_t voltage;
-        PcntUnit pcntUnit;
+        shared_ptr<PulseCounter> counter;
     };
 
     std::list<FencePin> pins;
@@ -107,9 +100,9 @@ private:
 class ElectricFenceMonitor
     : public Peripheral<EmptyConfiguration> {
 public:
-    ElectricFenceMonitor(const String& name, shared_ptr<MqttRoot> mqttRoot, PcntManager& pcnt, const ElectricFenceMonitorDeviceConfig& config)
+    ElectricFenceMonitor(const String& name, shared_ptr<MqttRoot> mqttRoot, const ElectricFenceMonitorDeviceConfig& config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
-        , monitor(name, mqttRoot, pcnt, config) {
+        , monitor(name, mqttRoot, config) {
     }
 
     void populateTelemetry(JsonObject& telemetryJson) override {
@@ -128,7 +121,7 @@ public:
     }
 
     unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const String& name, const ElectricFenceMonitorDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        return std::make_unique<ElectricFenceMonitor>(name, mqttRoot, services.pcntManager, deviceConfig);
+        return std::make_unique<ElectricFenceMonitor>(name, mqttRoot, deviceConfig);
     }
 };
 

--- a/main/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/main/peripherals/fence/ElectricFenceMonitor.hpp
@@ -60,8 +60,8 @@ public:
         LOGI("Initializing electric fence with pins %s", pinsDescription.c_str());
 
         for (auto& pinConfig : config.pins.get()) {
-            auto unit = pcnt.registerUnit(pinConfig.pin);
-            pins.push_back({ pinConfig.voltage, unit });
+            auto unit = pcnt.registerUnit(pinConfig.pin, nanoseconds::zero());
+            pins.emplace_back(pinConfig.voltage, unit);
         }
 
         // TODO Use PCNT event callbacks instead?

--- a/main/peripherals/flow_control/FlowControl.hpp
+++ b/main/peripherals/flow_control/FlowControl.hpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include <kernel/Configuration.hpp>
-#include <kernel/PcntManager.hpp>
 #include <kernel/mqtt/MqttDriver.hpp>
 #include <peripherals/Motorized.hpp>
 #include <peripherals/Peripheral.hpp>
@@ -31,7 +30,6 @@ public:
     FlowControl(
         const String& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PcntManager& pcnt,
         ValveControlStrategy& strategy,
         InternalPinPtr pin,
         double qFactor,
@@ -40,7 +38,7 @@ public:
         , valve(name, strategy, mqttRoot, [this]() {
             publishTelemetry();
         })
-        , flowMeter(name, mqttRoot, pcnt, pin, qFactor, measurementFrequency) {
+        , flowMeter(name, mqttRoot, pin, qFactor, measurementFrequency) {
     }
 
     void configure(const FlowControlConfig& config) override {
@@ -92,7 +90,6 @@ public:
             name,
             mqttRoot,
 
-            services.pcntManager,
             *strategy,
 
             flowMeterConfig.pin.get(),

--- a/main/peripherals/flow_meter/FlowMeter.hpp
+++ b/main/peripherals/flow_meter/FlowMeter.hpp
@@ -4,7 +4,6 @@
 
 #include <peripherals/Peripheral.hpp>
 #include <kernel/Configuration.hpp>
-#include <kernel/PcntManager.hpp>
 #include <kernel/mqtt/MqttDriver.hpp>
 #include <peripherals/flow_meter/FlowMeterComponent.hpp>
 #include <peripherals/flow_meter/FlowMeterConfig.hpp>
@@ -19,9 +18,9 @@ namespace farmhub::peripherals::flow_meter {
 class FlowMeter
     : public Peripheral<EmptyConfiguration> {
 public:
-    FlowMeter(const String& name, shared_ptr<MqttRoot> mqttRoot, PcntManager& pcnt, InternalPinPtr pin, double qFactor, milliseconds measurementFrequency)
+    FlowMeter(const String& name, shared_ptr<MqttRoot> mqttRoot, InternalPinPtr pin, double qFactor, milliseconds measurementFrequency)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
-        , flowMeter(name, mqttRoot, pcnt, pin, qFactor, measurementFrequency) {
+        , flowMeter(name, mqttRoot, pin, qFactor, measurementFrequency) {
     }
 
     void populateTelemetry(JsonObject& telemetryJson) override {
@@ -40,7 +39,7 @@ public:
     }
 
     unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const String& name, const FlowMeterDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        return make_unique<FlowMeter>(name, mqttRoot, services.pcntManager, deviceConfig.pin.get(), deviceConfig.qFactor.get(), deviceConfig.measurementFrequency.get());
+        return make_unique<FlowMeter>(name, mqttRoot, deviceConfig.pin.get(), deviceConfig.qFactor.get(), deviceConfig.measurementFrequency.get());
     }
 };
 


### PR DESCRIPTION
Switched to interrupt-based counting. This should not keep the device awake, and it doesn't seem to suffer from glitches.

Most likely the phantom-counts on the PCNT unit came from the device going to sleep.

Fixes #273.