### PR TITLE
Fix fantom leaks for real

### DIFF
--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -215,7 +215,7 @@ private:
         }
 
         // Don't sleep while we are performing the update
-        PowerManagementLockGuard sleepLock(PowerManager::lightSleepLock);
+        PowerManagementLockGuard sleepLock(PowerManager::noLightSleep);
 
         auto contents = fs.readAll(UPDATE_FILE);
         if (!contents.has_value()) {

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -214,11 +214,8 @@ private:
             return "";
         }
 
-#ifdef CONFIG_PM_ENABLE
         // Don't sleep while we are performing the update
-        PowerManagementLock preventLightSleep { "firmware-update", ESP_PM_NO_LIGHT_SLEEP };
-        PowerManagementLockGuard sleepLock(preventLightSleep);
-#endif
+        PowerManagementLockGuard sleepLock(PowerManager::lightSleepLock);
 
         auto contents = fs.readAll(UPDATE_FILE);
         if (!contents.has_value()) {

--- a/main/kernel/PowerManager.hpp
+++ b/main/kernel/PowerManager.hpp
@@ -111,7 +111,7 @@ public:
     }
 #endif
 
-    static PowerManagementLock lightSleepLock;
+    static PowerManagementLock noLightSleep;
 
 private:
     static bool shouldSleepWhenIdle(bool requestedSleepWhenIdle) {
@@ -145,6 +145,6 @@ private:
 #endif
 };
 
-PowerManagementLock PowerManager::lightSleepLock("light-sleep", ESP_PM_NO_LIGHT_SLEEP);
+PowerManagementLock PowerManager::noLightSleep("no-light-sleep", ESP_PM_NO_LIGHT_SLEEP);
 
 }    // namespace farmhub::kernel

--- a/main/kernel/PulseCounter.hpp
+++ b/main/kernel/PulseCounter.hpp
@@ -1,35 +1,60 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 
 #include <driver/gpio.h>
+#include <driver/rtc_io.h>
 
+#include <kernel/BootClock.hpp>
+#include <kernel/Concurrent.hpp>
+#include <kernel/Log.hpp>
 #include <kernel/Pin.hpp>
+#include <kernel/PowerManager.hpp>
 
 namespace farmhub::kernel {
 
 /**
  * Interrupt-based pulse-counter for low-frequency signals.
+ *
+ * It uses the RTC GPIO matrix to detect rising and falling edges on a GPIO pin.
+ * Keeps the device out of light sleep while a pulse is being detected.
+ *
  */
 class PulseCounter {
 public:
     PulseCounter(InternalPinPtr pin)
         : pin(pin) {
+        auto gpio = pin->getGpio();
+
         // Configure the GPIO pin as an input
         gpio_config_t config = {
-            .pin_bit_mask = 1ULL << pin->getGpio(),
+            .pin_bit_mask = 1ULL << gpio,
             .mode = GPIO_MODE_INPUT,
             .pull_up_en = GPIO_PULLUP_DISABLE,
-            .pull_down_en = GPIO_PULLDOWN_DISABLE   ,
-            .intr_type = GPIO_INTR_POSEDGE,
+            .pull_down_en = GPIO_PULLDOWN_ENABLE,
+            .intr_type = GPIO_INTR_ANYEDGE,
         };
-        gpio_config(&config);
+        ESP_ERROR_CHECK(gpio_config(&config));
+
+        // Use the same configuration while in light sleep
+        ESP_ERROR_CHECK(gpio_sleep_sel_dis(gpio));
+
+        ESP_ERROR_CHECK(rtc_gpio_wakeup_enable(gpio, GPIO_INTR_HIGH_LEVEL));
+
+        // TODO Where should this be called?
+        ESP_ERROR_CHECK(esp_sleep_enable_gpio_wakeup());
 
         // Attach the ISR handler to the GPIO pin
-        gpio_isr_handler_add(pin->getGpio(), interruptHandler, this);
+        ESP_ERROR_CHECK(gpio_isr_handler_add(gpio, interruptHandler, this));
 
         LOGTD(Tag::PCNT, "Registered interrupt-based pulse counter unit on pin %s",
             pin->getName().c_str());
+
+        // TODO Turn this into a single task that handles all pulse counters
+        Task::run(pin->getName(), 4096, [this](Task& task) {
+            runLoop();
+        });
     }
 
     uint32_t getCount() const {
@@ -51,13 +76,70 @@ public:
     }
 
 private:
-    static void IRAM_ATTR interruptHandler(void *arg) {
-        auto self = static_cast<PulseCounter*>(arg);
-        self->counter++;
+    static void IRAM_ATTR interruptHandler(void* arg);
+
+    // The amount of time we wait for the end of a pulse before we consider it a timeout
+    static constexpr microseconds maxHighTime = 100ms;
+
+    void runLoop() {
+        std::optional<time_point<boot_clock>> lastRisingEdge;
+        while (true) {
+            ticks timeout;
+            if (lastRisingEdge.has_value()) {
+                auto elapsedSinceLastRisingEdge = boot_clock::now() - lastRisingEdge.value();
+                if (elapsedSinceLastRisingEdge > maxHighTime) {
+                    // We've timed out, let the device sleep again, and forget this rising edge
+                    // as it was clearly not the beginning of an actual pulse
+                    lastRisingEdge.reset();
+                    preventLightSleep.reset();
+                } else {
+                    timeout = floor<ticks>(maxHighTime - elapsedSinceLastRisingEdge);
+                }
+            } else {
+                timeout = ticks::max();
+            }
+
+            auto event = eventQueue.pollIn(timeout);
+            if (event.has_value()) {
+                switch (event.value()) {
+                    case PulseCounterEvent::RisingEdgeDetected:
+                        if (!lastRisingEdge.has_value()) {
+                            // Beginning of new pulse detected, prevent light sleep
+                            // until the end of the pulse or a timeout
+                            lastRisingEdge = boot_clock::now();
+                            preventLightSleep.emplace(PowerManager::lightSleepLock);
+                        }
+                        break;
+                    case PulseCounterEvent::FallingEdgeDetected:
+                        if (lastRisingEdge.has_value()) {
+                            // End of pulse detected, increase count and let the device sleep again
+                            counter++;
+                            lastRisingEdge.reset();
+                            preventLightSleep.reset();
+                        }
+                        break;
+                }
+            }
+        }
     }
 
     const InternalPinPtr pin;
     std::atomic<uint32_t> counter { 0 };
+
+    enum class PulseCounterEvent {
+        RisingEdgeDetected,
+        FallingEdgeDetected,
+    };
+
+    CopyQueue<PulseCounterEvent> eventQueue { pin->getName(), 16 };
+    std::optional<PowerManagementLockGuard> preventLightSleep;
 };
+
+void IRAM_ATTR PulseCounter::interruptHandler(void* arg) {
+    auto self = static_cast<PulseCounter*>(arg);
+    self->eventQueue.offerFromISR(self->pin->digitalRead()
+            ? PulseCounterEvent::RisingEdgeDetected
+            : PulseCounterEvent::FallingEdgeDetected);
+}
 
 }    // namespace farmhub::kernel

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -256,7 +256,7 @@ private:
         switch (state) {
             case WatchdogState::Started:
                 LOGI("Watchdog started");
-                sleepLock.emplace(preventLightSleep);
+                sleepLock.emplace(PowerManager::noLightSleep);
                 break;
             case WatchdogState::Cancelled:
                 LOGI("Watchdog cancelled");
@@ -343,7 +343,6 @@ private:
     DoorState overrideState = DoorState::NONE;
     time_point<system_clock> overrideUntil = time_point<system_clock>::min();
 
-    PowerManagementLock preventLightSleep { name, ESP_PM_NO_LIGHT_SLEEP };
     std::optional<PowerManagementLockGuard> sleepLock;
 };
 

--- a/main/peripherals/valve/ValveComponent.hpp
+++ b/main/peripherals/valve/ValveComponent.hpp
@@ -339,7 +339,7 @@ private:
     void open() {
         LOGI("Opening valve '%s'", name.c_str());
         {
-            PowerManagementLockGuard noSleep(preventLightSleep);
+            PowerManagementLockGuard sleepLock(PowerManager::noLightSleep);
             strategy.open();
         }
         setState(ValveState::OPEN);
@@ -348,7 +348,7 @@ private:
     void close() {
         LOGI("Closing valve '%s'", name.c_str());
         {
-            PowerManagementLockGuard noSleep(preventLightSleep);
+            PowerManagementLockGuard sleepLock(PowerManager::noLightSleep);
             strategy.close();
         }
         setState(ValveState::CLOSED);
@@ -388,8 +388,6 @@ private:
                 name.c_str(), static_cast<int>(state));
         }
     }
-
-    PowerManagementLock preventLightSleep { name, ESP_PM_NO_LIGHT_SLEEP };
 
     NvsStore nvs;
     ValveControlStrategy& strategy;


### PR DESCRIPTION
Fixes #273.
For real now, I hope.

Here's how this works:

We are still using interrupts to count pulses, but when we see a rising edge, we disable light sleep until we see a falling one. If we don't see a falling one in a short while, we assume we are stuck in `HIGH`, and just assume we are not getting any more edges for a while, so we go back to sleep.

There is a bit of nastiness with how the interrupt is set up wrt light sleep. The interrupt is detecting edges (rising and falling), but wakeup can only happen based on levels.

In normal operation we only sleep while the output is `LOW`, so the wakeup is configured to `HIGH`. However, when we time out in the `HIGH` input state, we need to set the wakeup to `LOW`. If we don't do this, the system interrupt handler will be swamped with interrupts (even though it will never make it to _our_ interrupt handler), and at some point the watchdog timer will kill the system interrupt handler, resulting in a panic. Not nice!

To avoid this, we have to constantly switch to wake up on the right level.

Relevant material:

- https://github.com/LIFsCode/ELOC-3.0/commit/882d1a5ae5e468e573a1c2a444ffe0d6782fed75#diff-fae1224ef719c87335eef5b5cdc7cc89512b927886ad697530875a8ba78cdce4L851
- https://github.com/espressif/esp-idf/issues/13444

## TODO

- [ ] Check what happens with non-RTC GPIOs.
