### PR TITLE
Fix analogRead timeout handling

### DIFF
--- a/main/kernel/Pin.hpp
+++ b/main/kernel/Pin.hpp
@@ -154,10 +154,23 @@ public:
         ESP_ERROR_CHECK(adc_oneshot_del_unit(handle));
     }
 
-    int analogRead() const {
+    /**
+     * @brief Read an analog value. Returns `std::nullopt` if the read fails.
+     */
+    std::optional<int> analogRead() const {
         int value;
-        ESP_ERROR_CHECK(adc_oneshot_read(handle, channel, &value));
-        return value;
+        esp_err_t err = adc_oneshot_read(handle, channel, &value);
+        switch (err) {
+            case ESP_OK:
+                return value;
+                break;
+            case ESP_ERR_TIMEOUT:
+                return std::nullopt;
+            default:
+                ESP_ERROR_CHECK(err);
+                // Won't get this far
+                abort();
+        }
     }
 
     const std::string& getName() const {

--- a/main/kernel/drivers/BatteryDriver.hpp
+++ b/main/kernel/drivers/BatteryDriver.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include <kernel/Pin.hpp>
 #include <kernel/Telemetry.hpp>
 
@@ -28,8 +30,15 @@ public:
     }
 
     float getVoltage() {
-        auto batteryLevel = analogPin.analogRead();
-        return batteryLevel * 3.3 / 4096 * voltageDividerRatio;
+        for (int trial = 0; trial < 5; trial++) {
+            auto batteryLevel = analogPin.analogRead();
+            if (!batteryLevel.has_value()) {
+                LOGE("Failed to read battery level");
+                continue;
+            }
+            return batteryLevel.value() * 3.3 / 4096 * voltageDividerRatio;
+        }
+        return std::numeric_limits<float>::quiet_NaN();
     }
 
 private:

--- a/main/peripherals/environment/SoilMoistureSensor.hpp
+++ b/main/peripherals/environment/SoilMoistureSensor.hpp
@@ -39,13 +39,17 @@ public:
     }
 
     void populateTelemetry(JsonObject& json) override {
-        uint16_t soilMoistureValue = pin.analogRead();
+        std::optional<uint16_t> soilMoistureValue = pin.analogRead();
+        if (!soilMoistureValue.has_value()) {
+            LOGD("Failed to read soil moisture value");
+            return;
+        }
         LOGV("Soil moisture value: %d",
-            soilMoistureValue);
+            soilMoistureValue.value());
 
         const double run = waterValue - airValue;
         const double rise = 100;
-        const double delta = soilMoistureValue - airValue;
+        const double delta = soilMoistureValue.value() - airValue;
         double moisture = (delta * rise) / run;
 
         json["moisture"] = moisture;


### PR DESCRIPTION
It appears that reading analog values can time out. I'm wondering why this happens now, when it didn't happen before. Anyway, this is to stay safe and log.