### PR TITLE
Fix race condition around timed-out MQTT messages

### DIFF
--- a/data-templates/test-mk6.json
+++ b/data-templates/test-mk6.json
@@ -1,0 +1,20 @@
+{
+  "instance": "test-mk6-xxx",
+  "id": "UD060x-xxx",
+  "location": "bumblebee",
+  "peripherals": [
+    {
+      "name": "flow-control-a",
+      "type": "flow-control",
+      "params": {
+        "valve": {
+          "motor": "a"
+        },
+        "flow-meter": {
+          "pin": "A1"
+        }
+      }
+    }
+  ],
+  "sleepWhenIdle": true
+}

--- a/lookup-backtrace.py
+++ b/lookup-backtrace.py
@@ -26,18 +26,11 @@ def parse_and_run_addr2line(line):
         process_addresses(addresses)
 
 def process_addresses(addresses):
-    # Prepare the addr2line command
-    cmd = ["xtensa-esp32-elf-addr2line", "-f", "-e", "build/ugly-duckling.elf"] + addresses
+    cmd = ["xtensa-esp32-elf-addr2line", "--pretty-print", "--demangle", "--basenames", "--functions", "--exe", "build/ugly-duckling.elf"] + addresses
     try:
-        # Run the addr2line command
         result = subprocess.run(cmd, text=True, capture_output=True)
-        # Split output into lines
-        lines = result.stdout.strip().splitlines()
-        # Process lines in pairs
-        for i in range(0, len(lines), 2):
-            function_name = lines[i].strip() if i < len(lines) else "unknown"
-            source_info = lines[i + 1].strip() if i + 1 < len(lines) else "unknown"
-            print(f"  -- {source_info} -- {function_name}")
+        for line in result.stdout.strip().splitlines():
+            print(f"  -- ${line}")
     except Exception as e:
         print(f"Error running addr2line: {e}")
 


### PR DESCRIPTION
When a message sent from an incoming message handler would time out, the incoming handler task would proceed and get deleted eventually. If later a `PUBLISHED` event arrived for the message sent, we still tried to notify the (now deleted) task, and cause a crash.

The code has now been reorganized to make sure we don't try to notify deleted tasks.

Fixes #340.