### PR TITLE
Allow multiple interrupt-based pulse counters to be registered

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -633,7 +633,7 @@ private:
     TDeviceConfiguration& deviceConfig = deviceDefinition.config;
 
     shared_ptr<MqttRoot> mqttDeviceRoot = kernel.mqtt.forRoot(locationPrefix() + "devices/ugly-duckling/" + deviceConfig.instance.get());
-    PeripheralManager peripheralManager { kernel.i2c, deviceDefinition.pcnt, deviceDefinition.pwm, kernel.switches, mqttDeviceRoot };
+    PeripheralManager peripheralManager { kernel.i2c, deviceDefinition.pcnt, deviceDefinition.pulseCounterManager, deviceDefinition.pwm, kernel.switches, mqttDeviceRoot };
 
     TelemetryCollector deviceTelemetryCollector;
     MqttTelemetryPublisher deviceTelemetryPublisher { mqttDeviceRoot, deviceTelemetryCollector };

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -8,6 +8,7 @@
 #include <kernel/Kernel.hpp>
 #include <kernel/Log.hpp>
 #include <kernel/PcntManager.hpp>
+#include <kernel/PulseCounter.hpp>
 #include <kernel/PwmManager.hpp>
 #include <kernel/drivers/BatteryDriver.hpp>
 #include <kernel/drivers/LedDriver.hpp>
@@ -96,6 +97,7 @@ public:
 public:
     LedDriver statusLed;
     PcntManager pcnt;
+    PulseCounterManager pulseCounterManager;
     PwmManager pwm;
     const InternalPinPtr bootPin;
 

--- a/main/kernel/drivers/WiFiDriver.hpp
+++ b/main/kernel/drivers/WiFiDriver.hpp
@@ -227,10 +227,12 @@ private:
                         connected = true;
                         connectingSince.reset();
                         networkConnecting.clear();
+                        LOGTD(Tag::WIFI, "Connected to the network");
                         break;
                     case WiFiEvent::DISCONNECTED:
                         connected = false;
                         networkConnecting.clear();
+                        LOGTD(Tag::WIFI, "Disconnected from the network");
                         break;
                     case WiFiEvent::PROVISIONING_FINISHED:
                         networkConnecting.clear();
@@ -260,11 +262,11 @@ private:
         if (provisioned) {
             wifi_config_t wifiConfig;
             ESP_ERROR_CHECK(esp_wifi_get_config(WIFI_IF_STA, &wifiConfig));
-            LOGTD(Tag::WIFI, "Connecting using stored credentials to %s",
+            LOGTI(Tag::WIFI, "Connecting using stored credentials to %s",
                 wifiConfig.sta.ssid);
             connectToStation(wifiConfig);
         } else {
-            LOGTD(Tag::WIFI, "No stored credentials, starting provisioning");
+            LOGTI(Tag::WIFI, "No stored credentials, starting provisioning");
             configPortalRunning.set();
             startProvisioning();
         }

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -531,17 +531,17 @@ private:
     void handleMqttEvent(int eventId, esp_mqtt_event_handle_t event) {
         switch (eventId) {
             case MQTT_EVENT_BEFORE_CONNECT: {
-                LOGTV(Tag::MQTT, "Before connecting to MQTT server");
+                LOGTD(Tag::MQTT, "Connecting to MQTT server %s:%lu", hostname.c_str(), port);
                 break;
             }
             case MQTT_EVENT_CONNECTED: {
-                LOGTV(Tag::MQTT, "Connected to MQTT server");
+                LOGTD(Tag::MQTT, "Connected to MQTT server");
                 mqttReady.set();
                 eventQueue.offerIn(MQTT_QUEUE_TIMEOUT, Connected { (bool) event->session_present });
                 break;
             }
             case MQTT_EVENT_DISCONNECTED: {
-                LOGTV(Tag::MQTT, "Disconnected from MQTT server");
+                LOGTD(Tag::MQTT, "Disconnected from MQTT server");
                 mqttReady.clear();
                 eventQueue.offerIn(MQTT_QUEUE_TIMEOUT, Disconnected {});
                 break;

--- a/main/peripherals/Peripheral.hpp
+++ b/main/peripherals/Peripheral.hpp
@@ -8,6 +8,7 @@
 #include <kernel/I2CManager.hpp>
 #include <kernel/Named.hpp>
 #include <kernel/PcntManager.hpp>
+#include <kernel/PulseCounter.hpp>
 #include <kernel/PwmManager.hpp>
 #include <kernel/Telemetry.hpp>
 #include <kernel/drivers/SwitchManager.hpp>
@@ -103,6 +104,7 @@ public:
 struct PeripheralServices {
     I2CManager& i2c;
     PcntManager& pcntManager;
+    PulseCounterManager& pulseCounterManager;
     PwmManager& pwmManager;
     SwitchManager& switches;
 };
@@ -173,10 +175,11 @@ public:
     PeripheralManager(
         I2CManager& i2c,
         PcntManager& pcntManager,
+        PulseCounterManager& pulseCounterManager,
         PwmManager& pwmManager,
         SwitchManager& switchManager,
         const shared_ptr<MqttRoot> mqttDeviceRoot)
-        : services({ i2c, pcntManager, pwmManager, switchManager })
+        : services({ i2c, pcntManager, pulseCounterManager, pwmManager, switchManager })
         , mqttDeviceRoot(mqttDeviceRoot) {
     }
 

--- a/main/peripherals/flow_control/FlowControl.hpp
+++ b/main/peripherals/flow_control/FlowControl.hpp
@@ -30,6 +30,7 @@ public:
     FlowControl(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
+        PulseCounterManager& pulseCounterManager,
         ValveControlStrategy& strategy,
         InternalPinPtr pin,
         double qFactor,
@@ -38,7 +39,7 @@ public:
         , valve(name, strategy, mqttRoot, [this]() {
             publishTelemetry();
         })
-        , flowMeter(name, mqttRoot, pin, qFactor, measurementFrequency) {
+        , flowMeter(name, mqttRoot, pulseCounterManager, pin, qFactor, measurementFrequency) {
     }
 
     void configure(const FlowControlConfig& config) override {
@@ -89,6 +90,7 @@ public:
         return make_unique<FlowControl>(
             name,
             mqttRoot,
+            services.pulseCounterManager,
 
             *strategy,
 

--- a/main/peripherals/flow_meter/FlowMeter.hpp
+++ b/main/peripherals/flow_meter/FlowMeter.hpp
@@ -18,9 +18,15 @@ namespace farmhub::peripherals::flow_meter {
 class FlowMeter
     : public Peripheral<EmptyConfiguration> {
 public:
-    FlowMeter(const std::string& name, shared_ptr<MqttRoot> mqttRoot, InternalPinPtr pin, double qFactor, milliseconds measurementFrequency)
+    FlowMeter(
+        const std::string& name,
+        shared_ptr<MqttRoot> mqttRoot,
+        PulseCounterManager& pulseCounterManager,
+        InternalPinPtr pin,
+        double qFactor,
+        milliseconds measurementFrequency)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
-        , flowMeter(name, mqttRoot, pin, qFactor, measurementFrequency) {
+        , flowMeter(name, mqttRoot, pulseCounterManager, pin, qFactor, measurementFrequency) {
     }
 
     void populateTelemetry(JsonObject& telemetryJson) override {
@@ -39,7 +45,7 @@ public:
     }
 
     unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const FlowMeterDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        return make_unique<FlowMeter>(name, mqttRoot, deviceConfig.pin.get(), deviceConfig.qFactor.get(), deviceConfig.measurementFrequency.get());
+        return make_unique<FlowMeter>(name, mqttRoot, services.pulseCounterManager, deviceConfig.pin.get(), deviceConfig.qFactor.get(), deviceConfig.measurementFrequency.get());
     }
 };
 

--- a/main/peripherals/flow_meter/FlowMeterComponent.hpp
+++ b/main/peripherals/flow_meter/FlowMeterComponent.hpp
@@ -23,6 +23,7 @@ public:
     FlowMeterComponent(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
+        PulseCounterManager& pulseCounterManager,
         InternalPinPtr pin,
         double qFactor,
         milliseconds measurementFrequency)
@@ -32,7 +33,7 @@ public:
         LOGI("Initializing flow meter on pin %s with Q = %.2f",
             pin->getName().c_str(), qFactor);
 
-        counter = make_shared<PulseCounter>(pin);
+        counter = pulseCounterManager.create(pin);
 
         auto now = boot_clock::now();
         lastMeasurement = now;


### PR DESCRIPTION
Like with the PCNT-based option we now have a manager that sets up the necessary global features on the first created counter. This way multiple pulse-counters can be configured, such as with the fence monitor peripheral.