### PR TITLE
Report only positive battery voltage

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -365,7 +365,10 @@ public:
     }
 
     void populateTelemetry(JsonObject& json) override {
-        json["voltage"] = kernel.getBatteryVoltage();
+        auto voltage = kernel.getBatteryVoltage();
+        if (voltage > 0) {
+            json["voltage"] = voltage;
+        }
     }
 
 private:


### PR DESCRIPTION
When battery voltage is measured at 0, we shouldn't report it. It just means we couldn't get a good reading (yet).

Fixes #346.