### PR TITLE
Do not clear MQTT commands

### DIFF
--- a/main/kernel/mqtt/MqttRoot.hpp
+++ b/main/kernel/mqtt/MqttRoot.hpp
@@ -39,14 +39,6 @@ public:
     bool registerCommand(const std::string& name, CommandHandler handler) {
         std::string suffix = "commands/" + name;
         return subscribe(suffix, QoS::ExactlyOnce, [this, name, suffix, handler](const std::string&, const JsonObject& request) {
-            // TODO Do exponential backoff when clear cannot be finished
-            // Clear topic and wait for it to be cleared
-            auto clearStatus = mqtt.clear(fullTopic(suffix), Retention::Retain, QoS::ExactlyOnce, std::chrono::seconds { 5 });
-            if (clearStatus != PublishStatus::Success) {
-                LOGTE(Tag::MQTT, "Failed to clear retained command topic '%s', status: %d",
-                    suffix.c_str(), static_cast<int>(clearStatus));
-            }
-
             JsonDocument responseDoc;
             auto response = responseDoc.to<JsonObject>();
             handler(request, response);


### PR DESCRIPTION
We don't need to do this anymore since we are not sending commands as retained from admin.

Fixes #248.