### PR TITLE
Suppress warning about both switches engaged on the chicken-door

### DIFF
--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -278,7 +278,7 @@ private:
         bool open = openSwitch.isEngaged();
         bool close = closedSwitch.isEngaged();
         if (open && close) {
-            LOGE("Both open and close switches are engaged");
+            LOGD("Both open and close switches are engaged");
             return DoorState::NONE;
         } else if (open) {
             return DoorState::OPEN;


### PR DESCRIPTION
Looks like we have some reversed switches on the current implementation of the hardware, and we end up having the switches reporting 0 when engaged, which leads to this error being sent to the server constantly somehow, yet the device works well.

This is not a fix, only a workaround for the time being, because the chicken-door device hardware is to be redesigned soon anyway. We can fix things properly then. For now we'll just make the message print at debug level instead.