### PR TITLE
Enable sleep-when-idle by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ This describes the device and its peripherals.
     "ntp": {
         "host": "pool.ntp.org", // NTP server host name, optional
     },
-    "sleepWhenIdle": true, // whether the device should sleep when idle, defaults to false
     "peripherals": [
       {
         "type": "chicken-door",

--- a/data-templates/chicken-door-mk6.json
+++ b/data-templates/chicken-door-mk6.json
@@ -15,6 +15,5 @@
         }
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/device-config-wokwi.json
+++ b/data-templates/device-config-wokwi.json
@@ -15,6 +15,5 @@
         }
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/flow-control-mk6-fully-equipped.json
+++ b/data-templates/flow-control-mk6-fully-equipped.json
@@ -30,6 +30,5 @@
         "water": 1105
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/flow-control-mk6.json
+++ b/data-templates/flow-control-mk6.json
@@ -14,6 +14,5 @@
         }
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/flow-control-mk7.json
+++ b/data-templates/flow-control-mk7.json
@@ -14,6 +14,5 @@
         }
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/flow-control-mk8-test.json
+++ b/data-templates/flow-control-mk8-test.json
@@ -3,6 +3,5 @@
   "id": "ud0800-001",
   "location": "bumblebee",
   "peripherals": [
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/i2c-mk7.json
+++ b/data-templates/i2c-mk7.json
@@ -9,6 +9,5 @@
         "scl": "A4"
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/multiplexer-mk6.json
+++ b/data-templates/multiplexer-mk6.json
@@ -18,6 +18,5 @@
         "pin": "relay:0"
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/data-templates/test-mk6.json
+++ b/data-templates/test-mk6.json
@@ -15,6 +15,5 @@
         }
       }
     }
-  ],
-  "sleepWhenIdle": true
+  ]
 }

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -46,7 +46,7 @@ public:
 
     ArrayProperty<JsonAsString> peripherals { this, "peripherals" };
 
-    Property<bool> sleepWhenIdle { this, "sleepWhenIdle", false };
+    Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
 
     Property<seconds> publishInterval { this, "publishInterval", 1min };
     Property<Level> publishLogs { this, "publishLogs", Level::Info };


### PR DESCRIPTION
Devices can now go to light sleep on idle safely, even for non-battery-driven versions. Even for these using less energy means for example more reliable temperature measurements.

Enabling debug logging will disable the feature, just like in the past, and so does the Wokwi build.