### PR TITLE
Fix battery stack overflow

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -272,7 +272,7 @@ public:
                 enterLowPowerDeepSleep();
             }
 
-            Task::loop("battery", 2048, [this](Task& task) {
+            Task::loop("battery", 2560, [this](Task& task) {
                 checkBatteryVoltage(task);
             });
         }


### PR DESCRIPTION
By the age-old custom of increasing the stack size.

Fixes #349.