### PR TITLE
Improve init order of the application

### DIFF
--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -207,14 +207,6 @@ public:
         std::shared_ptr<Kernel> kernel)
         : kernel(kernel)
         , battery(battery) {
-
-        LOGD("   ______                   _    _       _");
-        LOGD("  |  ____|                 | |  | |     | |");
-        LOGD("  | |__ __ _ _ __ _ __ ___ | |__| |_   _| |__");
-        LOGD("  |  __/ _` | '__| '_ ` _ \\|  __  | | | | '_ \\");
-        LOGD("  | | | (_| | |  | | | | | | |  | | |_| | |_) |");
-        LOGD("  |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s", farmhubVersion);
-        LOGD("  ");
     }
 
     const std::shared_ptr<Kernel> kernel;

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -62,16 +62,16 @@ public:
 
 class WiFiTelemetryProvider : public TelemetryProvider {
 public:
-    WiFiTelemetryProvider(WiFiDriver& wifi)
+    WiFiTelemetryProvider(const std::shared_ptr<WiFiDriver> wifi)
         : wifi(wifi) {
     }
 
     void populateTelemetry(JsonObject& json) override {
-        json["uptime"] = wifi.getUptime().count();
+        json["uptime"] = wifi->getUptime().count();
     }
 
 private:
-    WiFiDriver& wifi;
+    const std::shared_ptr<WiFiDriver> wifi;
 };
 
 class PowerManagementTelemetryProvider : public TelemetryProvider {
@@ -266,8 +266,8 @@ public:
             deviceConfig->model.get().c_str(),
             deviceConfig->instance.get().c_str(),
             deviceConfig->getHostname().c_str(),
-            kernel->wifi.getIp().value_or("<no-ip>").c_str(),
-            kernel->wifi.getSsid().value_or("<no-ssid>").c_str(),
+            kernel->wifi->getIp().value_or("<no-ip>").c_str(),
+            kernel->wifi->getSsid().value_or("<no-ssid>").c_str(),
             duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
     }
 

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -258,10 +258,14 @@ private:
 
 class ConfiguredKernel {
 public:
-    ConfiguredKernel(Queue<LogRecord>& logRecords, std::shared_ptr<TDeviceDefinition> deviceDefinition)
+    ConfiguredKernel(
+        Queue<LogRecord>& logRecords,
+        std::shared_ptr<TDeviceDefinition> deviceDefinition,
+        std::shared_ptr<Kernel<TDeviceConfiguration>> kernel)
         : deviceDefinition(deviceDefinition)
+        , kernel(kernel)
         , consoleProvider(logRecords, deviceDefinition->config->publishLogs.get())
-        , battery(deviceDefinition->createBatteryDriver(kernel.i2c)) {
+        , battery(deviceDefinition->createBatteryDriver(kernel->i2c)) {
         if (battery != nullptr) {
             // If the battery voltage is below threshold, we should not boot yet.
             // This is to prevent the device from booting and immediately shutting down
@@ -296,13 +300,13 @@ public:
     }
 
     const std::shared_ptr<TDeviceDefinition> deviceDefinition;
+    const std::shared_ptr<Kernel<TDeviceConfiguration>> kernel;
     ConsoleProvider consoleProvider;
-    Kernel<TDeviceConfiguration> kernel { deviceDefinition->config, deviceDefinition->mqttConfig, deviceDefinition->statusLed };
     const shared_ptr<BatteryDriver> battery;
 
 private:
 #ifdef FARMHUB_DEBUG
-    ConsolePrinter consolePrinter { battery, kernel.wifi };
+    ConsolePrinter consolePrinter { battery, kernel->wifi };
 #endif
 
     void checkBatteryVoltage(Task& task) {
@@ -378,15 +382,16 @@ private:
 
 class Device {
 public:
-    Device(std::shared_ptr<TDeviceDefinition> deviceDefinition)
-    : deviceDefinition(deviceDefinition) {
-        kernel.switches.onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
+    Device(std::shared_ptr<TDeviceDefinition> deviceDefinition, std::shared_ptr<Kernel<TDeviceConfiguration>> kernel)
+    : deviceDefinition(deviceDefinition)
+    , kernel(kernel) {
+        kernel->switches.onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
             if (duration >= 15s) {
                 LOGI("Factory reset triggered after %lld ms", duration.count());
-                kernel.performFactoryReset(true);
+                this->kernel->performFactoryReset(true);
             } else if (duration >= 5s) {
                 LOGI("WiFi reset triggered after %lld ms", duration.count());
-                kernel.performFactoryReset(false);
+                this->kernel->performFactoryReset(false);
             }
         });
 
@@ -400,12 +405,12 @@ public:
             LOGI("No battery configured");
         }
 
-        deviceTelemetryCollector.registerProvider("wifi", std::make_shared<WiFiTelemetryProvider>(kernel.wifi));
+        deviceTelemetryCollector.registerProvider("wifi", std::make_shared<WiFiTelemetryProvider>(kernel->wifi));
 
 #if defined(FARMHUB_DEBUG) || defined(FARMHUB_REPORT_MEMORY)
         deviceTelemetryCollector.registerProvider("memory", std::make_shared<MemoryTelemetryProvider>());
 #endif
-        deviceTelemetryCollector.registerProvider("pm", std::make_shared<PowerManagementTelemetryProvider>(kernel.powerManager));
+        deviceTelemetryCollector.registerProvider("pm", std::make_shared<PowerManagementTelemetryProvider>(kernel->powerManager));
 
         deviceDefinition->registerPeripheralFactories(peripheralManager);
 
@@ -445,7 +450,7 @@ public:
         });
 
         // We want RTC to be in sync before we start setting up peripherals
-        kernel.getRtcInSyncState().awaitSet();
+        kernel->getRtcInSyncState().awaitSet();
 
         JsonDocument peripheralsInitDoc;
         JsonArray peripheralsInitJson = peripheralsInitDoc.to<JsonArray>();
@@ -482,14 +487,14 @@ public:
                 deviceConfig->store(device, false);
                 // TODO Remove redundant mentions of "ugly-duckling"
                 json["app"] = "ugly-duckling";
-                json["version"] = kernel.version;
+                json["version"] = kernel->version;
                 json["reset"] = esp_reset_reason();
                 json["wakeup"] = esp_sleep_get_wakeup_cause();
                 json["bootCount"] = bootCount++;
                 json["time"] = duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
                 json["state"] = static_cast<int>(initState);
                 json["peripherals"].to<JsonArray>().set(peripheralsInitJson);
-                json["sleepWhenIdle"] = kernel.powerManager.sleepWhenIdle;
+                json["sleepWhenIdle"] = kernel->powerManager.sleepWhenIdle;
 
                 reportPreviousCrashIfAny(json);
             },
@@ -501,7 +506,7 @@ public:
             publishTelemetry();
 
             // Signal that we are still alive
-            kernel.watchdog.restart();
+            this->kernel->watchdog.restart();
 
             // We always wait at least this much between telemetry updates
             const auto debounceInterval = 500ms;
@@ -513,16 +518,16 @@ public:
             telemetryPublishQueue.pollIn(timeout);
         });
 
-        kernel.getKernelReadyState().set();
+        kernel->getKernelReadyState().set();
 
         LOGI("Device ready in %.2f s (kernel version %s on %s instance '%s' with hostname '%s' and IP '%s', SSID '%s', current time is %lld)",
             duration_cast<milliseconds>(boot_clock::now().time_since_epoch()).count() / 1000.0,
-            kernel.version.c_str(),
+            kernel->version.c_str(),
             deviceConfig->model.get().c_str(),
             deviceConfig->instance.get().c_str(),
             deviceConfig->getHostname().c_str(),
-            kernel.wifi.getIp().value_or("<no-ip>").c_str(),
-            kernel.wifi.getSsid().value_or("<no-ssid>").c_str(),
+            kernel->wifi.getIp().value_or("<no-ip>").c_str(),
+            kernel->wifi.getSsid().value_or("<no-ssid>").c_str(),
             duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
     }
 
@@ -634,11 +639,11 @@ private:
     Queue<LogRecord> logRecords { "logs", 32 };
     const std::shared_ptr<TDeviceDefinition> deviceDefinition;
     const std::shared_ptr<TDeviceConfiguration> deviceConfig = deviceDefinition->config;
-    ConfiguredKernel configuredKernel { logRecords, deviceDefinition };
-    Kernel<TDeviceConfiguration>& kernel = configuredKernel.kernel;
+    const std::shared_ptr<Kernel<TDeviceConfiguration>> kernel;
+    ConfiguredKernel configuredKernel { logRecords, deviceDefinition, kernel };
 
-    shared_ptr<MqttRoot> mqttDeviceRoot = kernel.mqtt.forRoot(locationPrefix() + "devices/ugly-duckling/" + deviceConfig->instance.get());
-    PeripheralManager peripheralManager { kernel.i2c, deviceDefinition->pcnt, deviceDefinition->pulseCounterManager, deviceDefinition->pwm, kernel.switches, mqttDeviceRoot };
+    shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt.forRoot(locationPrefix() + "devices/ugly-duckling/" + deviceConfig->instance.get());
+    PeripheralManager peripheralManager { kernel->i2c, deviceDefinition->pcnt, deviceDefinition->pulseCounterManager, deviceDefinition->pwm, kernel->switches, mqttDeviceRoot };
 
     TelemetryCollector deviceTelemetryCollector;
     MqttTelemetryPublisher deviceTelemetryPublisher { mqttDeviceRoot, deviceTelemetryCollector };
@@ -646,7 +651,7 @@ private:
         telemetryPublishQueue.offer(true);
     } };
 
-    FileSystem& fs { kernel.fs };
+    FileSystem& fs { kernel->fs };
     EchoCommand echoCommand;
     RestartCommand restartCommand;
     SleepCommand sleepCommand;
@@ -655,7 +660,7 @@ private:
     FileWriteCommand fileWriteCommand { fs };
     FileRemoveCommand fileRemoveCommand { fs };
     HttpUpdateCommand httpUpdateCommand { [this](const std::string& url) {
-        kernel.prepareUpdate(url);
+        kernel->prepareUpdate(url);
     } };
 
     CopyQueue<bool> telemetryPublishQueue { "telemetry-publish", 1 };

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -56,7 +56,7 @@ namespace farmhub::devices {
 #ifdef FARMHUB_DEBUG
 class ConsolePrinter {
 public:
-    ConsolePrinter(const std::shared_ptr<BatteryDriver> battery, WiFiDriver& wifi)
+    ConsolePrinter(const std::shared_ptr<BatteryManager> battery, WiFiDriver& wifi)
         : battery(battery)
         , wifi(wifi) {
         status.reserve(256);
@@ -140,7 +140,7 @@ private:
 
     int counter;
     std::string status;
-    const std::shared_ptr<BatteryDriver> battery;
+    const std::shared_ptr<BatteryManager> battery;
     WiFiDriver& wifi;
 };
 #endif
@@ -205,9 +205,11 @@ public:
     ConfiguredKernel(
         Queue<LogRecord>& logRecords,
         std::shared_ptr<TDeviceConfiguration> deviceConfig,
+        std::shared_ptr<BatteryManager> battery,
         std::shared_ptr<Kernel> kernel)
         : kernel(kernel)
-        , consoleProvider(logRecords, deviceConfig->publishLogs.get()) {
+        , consoleProvider(logRecords, deviceConfig->publishLogs.get())
+        , battery(battery) {
 
         LOGD("   ______                   _    _       _");
         LOGD("  |  ____|                 | |  | |     | |");
@@ -220,6 +222,7 @@ public:
 
     const std::shared_ptr<Kernel> kernel;
     ConsoleProvider consoleProvider;
+    const std::shared_ptr<BatteryManager> battery;
 
 private:
 #ifdef FARMHUB_DEBUG
@@ -238,7 +241,7 @@ public:
         , instance(deviceConfig->instance.get())
         , deviceDefinition(deviceDefinition)
         , kernel(kernel)
-        , configuredKernel(logRecords, deviceConfig, kernel) {
+        , configuredKernel(logRecords, deviceConfig, battery, kernel) {
         kernel->switches->onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
             if (duration >= 15s) {
                 LOGI("Factory reset triggered after %lld ms", duration.count());

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -390,7 +390,7 @@ public:
         , deviceDefinition(deviceDefinition)
         , kernel(kernel)
         , configuredKernel(logRecords, deviceConfig, deviceDefinition->createBatteryDriver(kernel->i2c), kernel) {
-        kernel->switches.onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
+        kernel->switches->onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
             if (duration >= 15s) {
                 LOGI("Factory reset triggered after %lld ms", duration.count());
                 this->kernel->performFactoryReset(true);
@@ -647,7 +647,7 @@ private:
     const std::shared_ptr<Kernel> kernel;
     ConfiguredKernel configuredKernel;
 
-    shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt.forRoot(locationPrefix() + "devices/ugly-duckling/" + instance);
+    shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt->forRoot(locationPrefix() + "devices/ugly-duckling/" + instance);
     PeripheralManager peripheralManager { kernel->i2c, deviceDefinition->pcnt, deviceDefinition->pulseCounterManager, deviceDefinition->pwm, kernel->switches, mqttDeviceRoot };
 
     TelemetryCollector deviceTelemetryCollector;

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -261,7 +261,7 @@ public:
     ConfiguredKernel(
         Queue<LogRecord>& logRecords,
         std::shared_ptr<TDeviceDefinition> deviceDefinition,
-        std::shared_ptr<Kernel<TDeviceConfiguration>> kernel)
+        std::shared_ptr<Kernel> kernel)
         : deviceDefinition(deviceDefinition)
         , kernel(kernel)
         , consoleProvider(logRecords, deviceDefinition->config->publishLogs.get())
@@ -300,7 +300,7 @@ public:
     }
 
     const std::shared_ptr<TDeviceDefinition> deviceDefinition;
-    const std::shared_ptr<Kernel<TDeviceConfiguration>> kernel;
+    const std::shared_ptr<Kernel> kernel;
     ConsoleProvider consoleProvider;
     const shared_ptr<BatteryDriver> battery;
 
@@ -382,7 +382,7 @@ private:
 
 class Device {
 public:
-    Device(std::shared_ptr<TDeviceDefinition> deviceDefinition, std::shared_ptr<Kernel<TDeviceConfiguration>> kernel)
+    Device(std::shared_ptr<TDeviceDefinition> deviceDefinition, std::shared_ptr<Kernel> kernel)
     : deviceDefinition(deviceDefinition)
     , kernel(kernel) {
         kernel->switches.onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
@@ -639,7 +639,7 @@ private:
     Queue<LogRecord> logRecords { "logs", 32 };
     const std::shared_ptr<TDeviceDefinition> deviceDefinition;
     const std::shared_ptr<TDeviceConfiguration> deviceConfig = deviceDefinition->config;
-    const std::shared_ptr<Kernel<TDeviceConfiguration>> kernel;
+    const std::shared_ptr<Kernel> kernel;
     ConfiguredKernel configuredKernel { logRecords, deviceDefinition, kernel };
 
     shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt.forRoot(locationPrefix() + "devices/ugly-duckling/" + deviceConfig->instance.get());

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -13,10 +13,10 @@
 #include <kernel/BootClock.hpp>
 #include <kernel/Command.hpp>
 #include <kernel/Concurrent.hpp>
+#include <kernel/DebugConsole.hpp>
 #include <kernel/Kernel.hpp>
 #include <kernel/Strings.hpp>
 #include <kernel/Task.hpp>
-#include <kernel/drivers/RtcDriver.hpp>
 #include <kernel/mqtt/MqttDriver.hpp>
 #include <kernel/mqtt/MqttRoot.hpp>
 
@@ -51,98 +51,6 @@ typedef farmhub::devices::Mk8Config TDeviceConfiguration;
 #endif
 
 namespace farmhub::devices {
-
-#ifdef FARMHUB_DEBUG
-class ConsolePrinter {
-public:
-    ConsolePrinter(const std::shared_ptr<BatteryManager> battery, WiFiDriver& wifi)
-        : battery(battery)
-        , wifi(wifi) {
-        status.reserve(256);
-        Task::loop("console", 3072, 1, [this](Task& task) {
-            printStatus();
-            task.delayUntilAtLeast(250ms);
-        });
-    }
-
-private:
-    void printStatus() {
-        static const char* spinner = "|/-\\";
-        static const int spinnerLength = strlen(spinner);
-        auto uptime = duration_cast<milliseconds>(boot_clock::now().time_since_epoch());
-
-        counter = (counter + 1) % spinnerLength;
-        status.clear();
-        status += "[" + std::string(1, spinner[counter]) + "] ";
-        status += "\033[33m" + std::string(farmhubVersion) + "\033[0m";
-        status += ", uptime: \033[33m" + toStringWithPrecision(uptime.count() / 1000.0f, 1) + "\033[0m s";
-        status += ", WIFI: " + std::string(wifiStatus()) + " (up \033[33m" + toStringWithPrecision(wifi.getUptime().count() / 1000.0f, 1) + "\033[0m s)";
-        status += ", RTC \033[33m" + std::string(RtcDriver::isTimeSet() ? "OK" : "UNSYNCED") + "\033[0m";
-        status += ", heap \033[33m" + toStringWithPrecision(heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0f, 2) + "\033[0m kB";
-        status += ", CPU: \033[33m" + std::to_string(esp_clk_cpu_freq() / 1000000) + "\033[0m MHz";
-
-        if (battery != nullptr) {
-            status += ", battery: \033[33m" + toStringWithPrecision(battery->getVoltage(), 2) + "\033[0m V";
-        }
-
-        printf("\033[1G\033[0K%s", status.c_str());
-        fflush(stdout);
-        fsync(fileno(stdout));
-    }
-
-    static const char* wifiStatus() {
-        auto netif = esp_netif_get_default_netif();
-        if (!netif) {
-            return "\033[0;33moff\033[0m";
-        }
-
-        wifi_mode_t mode;
-        ESP_ERROR_CHECK(esp_wifi_get_mode(&mode));
-
-        switch (mode) {
-            case WIFI_MODE_STA:
-                break;
-            case WIFI_MODE_NULL:
-                return "\033[0;33mNULL\033[0m";
-            case WIFI_MODE_AP:
-                return "\033[0;32mAP\033[0m";
-            case WIFI_MODE_APSTA:
-                return "\033[0;32mAPSTA\033[0m";
-            case WIFI_MODE_NAN:
-                return "\033[0;32mNAN\033[0m";
-            default:
-                return "\033[0;31m???\033[0m";
-        }
-
-        // Retrieve the current Wi-Fi station connection status
-        wifi_ap_record_t ap_info;
-        esp_err_t err = esp_wifi_sta_get_ap_info(&ap_info);
-        if (err != ESP_OK) {
-            return esp_err_to_name(err);
-        }
-
-        // Check IP address
-        esp_netif_ip_info_t ip_info;
-        err = esp_netif_get_ip_info(netif, &ip_info);
-        if (err != ESP_OK) {
-            return esp_err_to_name(err);
-        }
-
-        if (ip_info.ip.addr != 0) {
-            static char ip_str[32];
-            snprintf(ip_str, sizeof(ip_str), "\033[0;33m" IPSTR "\033[0m", IP2STR(&ip_info.ip));
-            return ip_str;
-        } else {
-            return "\033[0;33mIP?\033[0m";
-        }
-    }
-
-    int counter;
-    std::string status;
-    const std::shared_ptr<BatteryManager> battery;
-    WiFiDriver& wifi;
-};
-#endif
 
 class MemoryTelemetryProvider : public TelemetryProvider {
 public:
@@ -211,7 +119,7 @@ public:
         , deviceDefinition(deviceDefinition)
         , kernel(kernel)
 #ifdef FARMHUB_DEBUG
-        , consolePrinter(battery, kernel->wifi)
+        , debugConsole(battery, kernel->wifi)
 #endif
     {
         kernel->switches->onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
@@ -471,7 +379,7 @@ private:
     const std::shared_ptr<Kernel> kernel;
 
 #ifdef FARMHUB_DEBUG
-    ConsolePrinter consolePrinter;
+    DebugConsole debugConsole;
 #endif
 
     std::shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt->forRoot(locationPrefix() + "devices/ugly-duckling/" + instance);

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -23,7 +23,6 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using std::shared_ptr;
 using namespace farmhub::kernel;
 using namespace farmhub::kernel::drivers;
 using namespace farmhub::kernel::mqtt;
@@ -112,7 +111,7 @@ namespace farmhub::devices {
 #ifdef FARMHUB_DEBUG
 class ConsolePrinter {
 public:
-    ConsolePrinter(const shared_ptr<BatteryDriver> battery, WiFiDriver& wifi)
+    ConsolePrinter(const std::shared_ptr<BatteryDriver> battery, WiFiDriver& wifi)
         : battery(battery)
         , wifi(wifi) {
         status.reserve(256);
@@ -242,7 +241,7 @@ private:
 
 class MqttTelemetryPublisher : public TelemetryPublisher {
 public:
-    MqttTelemetryPublisher(shared_ptr<MqttRoot> mqttRoot, TelemetryCollector& telemetryCollector)
+    MqttTelemetryPublisher(std::shared_ptr<MqttRoot> mqttRoot, TelemetryCollector& telemetryCollector)
         : mqttRoot(mqttRoot)
         , telemetryCollector(telemetryCollector) {
     }
@@ -252,7 +251,7 @@ public:
     }
 
 private:
-    shared_ptr<MqttRoot> mqttRoot;
+    std::shared_ptr<MqttRoot> mqttRoot;
     TelemetryCollector& telemetryCollector;
 };
 
@@ -552,7 +551,7 @@ private:
     const std::shared_ptr<Kernel> kernel;
     ConfiguredKernel configuredKernel;
 
-    shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt->forRoot(locationPrefix() + "devices/ugly-duckling/" + instance);
+    std::shared_ptr<MqttRoot> mqttDeviceRoot = kernel->mqtt->forRoot(locationPrefix() + "devices/ugly-duckling/" + instance);
     PeripheralManager peripheralManager { kernel->i2c, deviceDefinition->pcnt, deviceDefinition->pulseCounterManager, deviceDefinition->pwm, kernel->switches, mqttDeviceRoot };
 
     TelemetryCollector deviceTelemetryCollector;

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -31,77 +31,22 @@ using namespace farmhub::kernel::mqtt;
 #include <devices/UglyDucklingMk4.hpp>
 typedef farmhub::devices::UglyDucklingMk4 TDeviceDefinition;
 typedef farmhub::devices::Mk4Config TDeviceConfiguration;
-
-/**
- * @brief Do not boot if battery is below this threshold.
- */
-static constexpr double BATTERY_BOOT_THRESHOLD = 0;
-
-/**
- * @brief Shutdown if battery drops below this threshold.
- */
-static constexpr double BATTERY_SHUTDOWN_THRESHOLD = 0;
-
 #elif defined(MK5)
 #include <devices/UglyDucklingMk5.hpp>
 typedef farmhub::devices::UglyDucklingMk5 TDeviceDefinition;
 typedef farmhub::devices::Mk5Config TDeviceConfiguration;
-
-/**
- * @brief Do not boot if battery is below this threshold.
- */
-static constexpr double BATTERY_BOOT_THRESHOLD = 0;
-
-/**
- * @brief Shutdown if battery drops below this threshold.
- */
-static constexpr double BATTERY_SHUTDOWN_THRESHOLD = 0;
-
 #elif defined(MK6)
 #include <devices/UglyDucklingMk6.hpp>
 typedef farmhub::devices::UglyDucklingMk6 TDeviceDefinition;
 typedef farmhub::devices::Mk6Config TDeviceConfiguration;
-
-/**
- * @brief Do not boot if battery is below this threshold.
- */
-static constexpr double BATTERY_BOOT_THRESHOLD = 3.9;
-
-/**
- * @brief Shutdown if battery drops below this threshold.
- */
-static constexpr double BATTERY_SHUTDOWN_THRESHOLD = 3.6;
-
 #elif defined(MK7)
 #include <devices/UglyDucklingMk7.hpp>
 typedef farmhub::devices::UglyDucklingMk7 TDeviceDefinition;
 typedef farmhub::devices::Mk7Config TDeviceConfiguration;
-
-/**
- * @brief Do not boot if battery is below this threshold.
- */
-static constexpr double BATTERY_BOOT_THRESHOLD = 3.7;
-
-/**
- * @brief Shutdown if battery drops below this threshold.
- */
-static constexpr double BATTERY_SHUTDOWN_THRESHOLD = 3.0;
-
 #elif defined(MK8)
 #include <devices/UglyDucklingMk8.hpp>
 typedef farmhub::devices::UglyDucklingMk8 TDeviceDefinition;
 typedef farmhub::devices::Mk8Config TDeviceConfiguration;
-
-/**
- * @brief Do not boot if battery is below this threshold.
- */
-static constexpr double BATTERY_BOOT_THRESHOLD = 3.2;
-
-/**
- * @brief Shutdown if battery drops below this threshold.
- */
-static constexpr double BATTERY_SHUTDOWN_THRESHOLD = 3.0;
-
 #else
 #error "No device defined"
 #endif

--- a/main/devices/Device.hpp
+++ b/main/devices/Device.hpp
@@ -13,7 +13,6 @@
 #include <kernel/BootClock.hpp>
 #include <kernel/Command.hpp>
 #include <kernel/Concurrent.hpp>
-#include <kernel/Console.hpp>
 #include <kernel/Kernel.hpp>
 #include <kernel/Strings.hpp>
 #include <kernel/Task.hpp>
@@ -203,12 +202,10 @@ private:
 class ConfiguredKernel {
 public:
     ConfiguredKernel(
-        Queue<LogRecord>& logRecords,
         std::shared_ptr<TDeviceConfiguration> deviceConfig,
         std::shared_ptr<BatteryManager> battery,
         std::shared_ptr<Kernel> kernel)
         : kernel(kernel)
-        , consoleProvider(logRecords, deviceConfig->publishLogs.get())
         , battery(battery) {
 
         LOGD("   ______                   _    _       _");
@@ -221,7 +218,6 @@ public:
     }
 
     const std::shared_ptr<Kernel> kernel;
-    ConsoleProvider consoleProvider;
     const std::shared_ptr<BatteryManager> battery;
 
 private:
@@ -241,7 +237,7 @@ public:
         , instance(deviceConfig->instance.get())
         , deviceDefinition(deviceDefinition)
         , kernel(kernel)
-        , configuredKernel(logRecords, deviceConfig, battery, kernel) {
+        , configuredKernel(deviceConfig, battery, kernel) {
         kernel->switches->onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [this](const Switch&, milliseconds duration) {
             if (duration >= 15s) {
                 LOGI("Factory reset triggered after %lld ms", duration.count());

--- a/main/devices/DeviceConfiguration.hpp
+++ b/main/devices/DeviceConfiguration.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <string>
+
+#include <kernel/Configuration.hpp>
+#include <kernel/NetworkUtil.hpp>
+#include <kernel/drivers/RtcDriver.hpp>
+
+using namespace farmhub::kernel;
+using namespace farmhub::kernel::drivers;
+
+namespace farmhub::devices {
+
+class DeviceConfiguration : public ConfigurationSection {
+public:
+    DeviceConfiguration(const std::string& defaultModel)
+        : model(this, "model", defaultModel)
+        , instance(this, "instance", getMacAddress()) {
+    }
+
+    Property<std::string> model;
+    Property<std::string> id { this, "id", "UNIDENTIFIED" };
+    Property<std::string> instance;
+    Property<std::string> location { this, "location" };
+
+    NamedConfigurationEntry<RtcDriver::Config> ntp { this, "ntp" };
+
+    ArrayProperty<JsonAsString> peripherals { this, "peripherals" };
+
+    Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
+
+    Property<seconds> publishInterval { this, "publishInterval", 1min };
+    Property<Level> publishLogs { this, "publishLogs", Level::Info };
+
+    virtual const std::string getHostname() {
+        std::string hostname = instance.get();
+        std::replace(hostname.begin(), hostname.end(), ':', '-');
+        std::erase(hostname, '?');
+        return hostname;
+    }
+};
+
+}    // namespace farmhub::devices

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -75,15 +75,13 @@ public:
     PwmManager pwm;
     const InternalPinPtr bootPin;
 
-private:
-    ConfigurationFile<TDeviceConfiguration> configFile { FileSystem::get(), "/device-config.json" };
-    ConfigurationFile<MqttDriver::Config> mqttConfigFile { FileSystem::get(), "/mqtt-config.json" };
-
-public:
-    TDeviceConfiguration& config = configFile.config;
-    MqttDriver::Config& mqttConfig = mqttConfigFile.config;
+    std::shared_ptr<TDeviceConfiguration> config = std::make_shared<TDeviceConfiguration>();
+    std::shared_ptr<MqttDriver::Config> mqttConfig = std::make_shared<MqttDriver::Config>();
 
 private:
+    ConfigurationFile<TDeviceConfiguration> configFile { FileSystem::get(), "/device-config.json", config };
+    ConfigurationFile<MqttDriver::Config> mqttConfigFile { FileSystem::get(), "/mqtt-config.json", mqttConfig };
+
     I2CEnvironmentFactory<Sht3xComponent> sht3xFactory { "sht3x", 0x44 /* Also supports 0x45 */ };
     // TODO Unify these two factories
     I2CEnvironmentFactory<Sht2xComponent> sht2xFactory { "sht2x", 0x40 /* Not configurable */ };

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -63,7 +63,7 @@ public:
         return {};
     }
 
-    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(I2CManager& i2c) {
+    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
         return nullptr;
     }
 
@@ -71,9 +71,9 @@ public:
     const PinPtr statusPin;
     const InternalPinPtr bootPin;
 
-    PcntManager pcnt;
-    PulseCounterManager pulseCounterManager;
-    PwmManager pwm;
+    const std::shared_ptr<PcntManager> pcnt { std::make_shared<PcntManager>() };
+    const std::shared_ptr<PulseCounterManager> pulseCounterManager { std::make_shared<PulseCounterManager>() };
+    const std::shared_ptr<PwmManager> pwm { std::make_shared<PwmManager>() };
 
 private:
     I2CEnvironmentFactory<Sht3xComponent> sht3xFactory { "sht3x", 0x44 /* Also supports 0x45 */ };

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -76,11 +76,9 @@ public:
     const InternalPinPtr bootPin;
 
     std::shared_ptr<TDeviceConfiguration> config = std::make_shared<TDeviceConfiguration>();
-    std::shared_ptr<MqttDriver::Config> mqttConfig = std::make_shared<MqttDriver::Config>();
 
 private:
     ConfigurationFile<TDeviceConfiguration> configFile { FileSystem::get(), "/device-config.json", config };
-    ConfigurationFile<MqttDriver::Config> mqttConfigFile { FileSystem::get(), "/mqtt-config.json", mqttConfig };
 
     I2CEnvironmentFactory<Sht3xComponent> sht3xFactory { "sht3x", 0x44 /* Also supports 0x45 */ };
     // TODO Unify these two factories

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -37,7 +37,7 @@ template <std::derived_from<DeviceConfiguration> TDeviceConfiguration>
 class DeviceDefinition {
 public:
     DeviceDefinition(PinPtr statusPin, InternalPinPtr bootPin)
-        : statusLed(make_shared<LedDriver>("status", statusPin))
+        : statusPin(statusPin)
         , bootPin(bootPin) {
     }
 
@@ -69,12 +69,12 @@ public:
     }
 
 public:
-    std::shared_ptr<LedDriver> statusLed;
+    const PinPtr statusPin;
+    const InternalPinPtr bootPin;
+
     PcntManager pcnt;
     PulseCounterManager pulseCounterManager;
     PwmManager pwm;
-    const InternalPinPtr bootPin;
-
     std::shared_ptr<TDeviceConfiguration> config = std::make_shared<TDeviceConfiguration>();
 
 private:

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -33,7 +33,6 @@ using namespace farmhub::peripherals::environment;
 
 namespace farmhub::devices {
 
-template <std::derived_from<DeviceConfiguration> TDeviceConfiguration>
 class DeviceDefinition {
 public:
     DeviceDefinition(PinPtr statusPin, InternalPinPtr bootPin)
@@ -75,11 +74,8 @@ public:
     PcntManager pcnt;
     PulseCounterManager pulseCounterManager;
     PwmManager pwm;
-    std::shared_ptr<TDeviceConfiguration> config = std::make_shared<TDeviceConfiguration>();
 
 private:
-    ConfigurationFile<TDeviceConfiguration> configFile { FileSystem::get(), "/device-config.json", config };
-
     I2CEnvironmentFactory<Sht3xComponent> sht3xFactory { "sht3x", 0x44 /* Also supports 0x45 */ };
     // TODO Unify these two factories
     I2CEnvironmentFactory<Sht2xComponent> sht2xFactory { "sht2x", 0x40 /* Not configurable */ };

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <concepts>
 #include <list>
 #include <memory>
 
 #include <ArduinoJson.h>
+
+#include <devices/DeviceConfiguration.hpp>
 
 #include <kernel/Kernel.hpp>
 #include <kernel/Log.hpp>
@@ -30,36 +33,7 @@ using namespace farmhub::peripherals::environment;
 
 namespace farmhub::devices {
 
-class DeviceConfiguration : public ConfigurationSection {
-public:
-    DeviceConfiguration(const std::string& defaultModel)
-        : model(this, "model", defaultModel)
-        , instance(this, "instance", getMacAddress()) {
-    }
-
-    Property<std::string> model;
-    Property<std::string> id { this, "id", "UNIDENTIFIED" };
-    Property<std::string> instance;
-    Property<std::string> location { this, "location" };
-
-    NamedConfigurationEntry<RtcDriver::Config> ntp { this, "ntp" };
-
-    ArrayProperty<JsonAsString> peripherals { this, "peripherals" };
-
-    Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
-
-    Property<seconds> publishInterval { this, "publishInterval", 1min };
-    Property<Level> publishLogs { this, "publishLogs", Level::Info };
-
-    virtual const std::string getHostname() {
-        std::string hostname = instance.get();
-        std::replace(hostname.begin(), hostname.end(), ':', '-');
-        std::erase(hostname, '?');
-        return hostname;
-    }
-};
-
-template <typename TDeviceConfiguration>
+template <std::derived_from<DeviceConfiguration> TDeviceConfiguration>
 class DeviceDefinition {
 public:
     DeviceDefinition(PinPtr statusPin, InternalPinPtr bootPin)

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -37,7 +37,7 @@ template <std::derived_from<DeviceConfiguration> TDeviceConfiguration>
 class DeviceDefinition {
 public:
     DeviceDefinition(PinPtr statusPin, InternalPinPtr bootPin)
-        : statusLed("status", statusPin)
+        : statusLed(make_shared<LedDriver>("status", statusPin))
         , bootPin(bootPin) {
     }
 
@@ -69,7 +69,7 @@ public:
     }
 
 public:
-    LedDriver statusLed;
+    std::shared_ptr<LedDriver> statusLed;
     PcntManager pcnt;
     PulseCounterManager pulseCounterManager;
     PwmManager pwm;

--- a/main/devices/DeviceDefinition.hpp
+++ b/main/devices/DeviceDefinition.hpp
@@ -63,7 +63,7 @@ public:
         return {};
     }
 
-    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
+    static std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
         return nullptr;
     }
 

--- a/main/devices/UglyDucklingMk4.hpp
+++ b/main/devices/UglyDucklingMk4.hpp
@@ -55,7 +55,7 @@ static InternalPinPtr TXD0 = InternalPin::registerPin("TXD0", GPIO_NUM_43);
 
 class UglyDucklingMk4 : public DeviceDefinition {
 public:
-    UglyDucklingMk4(shared_ptr<Mk4Config> config)
+    UglyDucklingMk4(std::shared_ptr<Mk4Config> config)
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 

--- a/main/devices/UglyDucklingMk4.hpp
+++ b/main/devices/UglyDucklingMk4.hpp
@@ -53,12 +53,10 @@ static InternalPinPtr RXD0 = InternalPin::registerPin("RXD0", GPIO_NUM_44);
 static InternalPinPtr TXD0 = InternalPin::registerPin("TXD0", GPIO_NUM_43);
 }    // namespace pins
 
-class UglyDucklingMk4 : public DeviceDefinition<Mk4Config> {
+class UglyDucklingMk4 : public DeviceDefinition {
 public:
-    UglyDucklingMk4()
-        : DeviceDefinition<Mk4Config>(
-              pins::STATUS,
-              pins::BOOT) {
+    UglyDucklingMk4(shared_ptr<Mk4Config> config)
+        : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {

--- a/main/devices/UglyDucklingMk5.hpp
+++ b/main/devices/UglyDucklingMk5.hpp
@@ -77,7 +77,7 @@ static InternalPinPtr TXD0 = InternalPin::registerPin("TXD0", GPIO_NUM_43);
 
 class UglyDucklingMk5 : public DeviceDefinition {
 public:
-    UglyDucklingMk5(shared_ptr<Mk5Config> config)
+    UglyDucklingMk5(std::shared_ptr<Mk5Config> config)
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 

--- a/main/devices/UglyDucklingMk5.hpp
+++ b/main/devices/UglyDucklingMk5.hpp
@@ -75,12 +75,10 @@ static InternalPinPtr RXD0 = InternalPin::registerPin("RXD0", GPIO_NUM_44);
 static InternalPinPtr TXD0 = InternalPin::registerPin("TXD0", GPIO_NUM_43);
 }    // namespace pins
 
-class UglyDucklingMk5 : public DeviceDefinition<Mk5Config> {
+class UglyDucklingMk5 : public DeviceDefinition {
 public:
-    UglyDucklingMk5()
-        : DeviceDefinition<Mk5Config>(
-              pins::STATUS,
-              pins::BOOT) {
+    UglyDucklingMk5(shared_ptr<Mk5Config> config)
+        : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -107,7 +107,7 @@ public:
         peripheralManager.registerFactory(chickenDoorFactory);
     }
 
-    LedDriver secondaryStatusLed { "status-2", pins::STATUS2 };
+    shared_ptr<LedDriver> secondaryStatusLed { make_shared<LedDriver>("status-2", pins::STATUS2) };
 
     Drv8833Driver motorDriver {
         pwm,

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -95,7 +95,7 @@ public:
         pins::LEDA_RED->digitalWrite(1);
     }
 
-    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(I2CManager& i2c) override {
+    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) override {
         return std::make_shared<AnalogBatteryDriver>(pins::BATTERY, 1.2424);
     }
 

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -116,7 +116,7 @@ public:
         pins::BIN1,
         pins::BIN2,
         pins::NFault,
-        config.motorNSleepPin.get()
+        config->motorNSleepPin.get()
     };
 
     const ServiceRef<PwmMotorDriver> motorA { "a", motorDriver.getMotorA() };

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -84,12 +84,11 @@ public:
     Property<PinPtr> motorNSleepPin { this, "motorNSleepPin", pins::IOC2 };
 };
 
-class UglyDucklingMk6 : public DeviceDefinition<Mk6Config> {
+class UglyDucklingMk6 : public DeviceDefinition {
 public:
-    UglyDucklingMk6()
-        : DeviceDefinition<Mk6Config>(
-              pins::STATUS,
-              pins::BOOT) {
+    UglyDucklingMk6(shared_ptr<Mk6Config> config)
+        : DeviceDefinition(pins::STATUS, pins::BOOT)
+        , motorDriver(pwm, pins::AIN1, pins::AIN2, pins::BIN1, pins::BIN2, pins::NFault, config->motorNSleepPin.get()) {
         // Switch off strapping pin
         // TODO: Add a LED driver instead
         pins::LEDA_RED->pinMode(Pin::Mode::Output);
@@ -109,15 +108,7 @@ public:
 
     shared_ptr<LedDriver> secondaryStatusLed { make_shared<LedDriver>("status-2", pins::STATUS2) };
 
-    Drv8833Driver motorDriver {
-        pwm,
-        pins::AIN1,
-        pins::AIN2,
-        pins::BIN1,
-        pins::BIN2,
-        pins::NFault,
-        config->motorNSleepPin.get()
-    };
+    Drv8833Driver motorDriver;
 
     const ServiceRef<PwmMotorDriver> motorA { "a", motorDriver.getMotorA() };
     const ServiceRef<PwmMotorDriver> motorB { "b", motorDriver.getMotorB() };

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -96,7 +96,11 @@ public:
     }
 
     static std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
-        return std::make_shared<AnalogBatteryDriver>(pins::BATTERY, 1.2424);
+        return std::make_shared<AnalogBatteryDriver>(pins::BATTERY, 1.2424, BatteryParameters {
+            .maximumVoltage = 4.1,
+            .bootThreshold = 3.8,
+            .shutdownThreshold = 3.4,
+        });
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -86,7 +86,7 @@ public:
 
 class UglyDucklingMk6 : public DeviceDefinition {
 public:
-    UglyDucklingMk6(shared_ptr<Mk6Config> config)
+    UglyDucklingMk6(std::shared_ptr<Mk6Config> config)
         : DeviceDefinition(pins::STATUS, pins::BOOT)
         , motorDriver(pwm, pins::AIN1, pins::AIN2, pins::BIN1, pins::BIN2, pins::NFault, config->motorNSleepPin.get()) {
         // Switch off strapping pin
@@ -106,7 +106,7 @@ public:
         peripheralManager.registerFactory(chickenDoorFactory);
     }
 
-    shared_ptr<LedDriver> secondaryStatusLed { make_shared<LedDriver>("status-2", pins::STATUS2) };
+    std::shared_ptr<LedDriver> secondaryStatusLed { std::make_shared<LedDriver>("status-2", pins::STATUS2) };
 
     Drv8833Driver motorDriver;
 

--- a/main/devices/UglyDucklingMk6.hpp
+++ b/main/devices/UglyDucklingMk6.hpp
@@ -95,7 +95,7 @@ public:
         pins::LEDA_RED->digitalWrite(1);
     }
 
-    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) override {
+    static std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
         return std::make_shared<AnalogBatteryDriver>(pins::BATTERY, 1.2424);
     }
 

--- a/main/devices/UglyDucklingMk7.hpp
+++ b/main/devices/UglyDucklingMk7.hpp
@@ -88,7 +88,7 @@ public:
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
-    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(I2CManager& i2c) override {
+    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) override {
         return std::make_shared<Bq27220Driver>(i2c, pins::SDA, pins::SCL);
     }
 

--- a/main/devices/UglyDucklingMk7.hpp
+++ b/main/devices/UglyDucklingMk7.hpp
@@ -82,12 +82,10 @@ public:
     }
 };
 
-class UglyDucklingMk7 : public DeviceDefinition<Mk7Config> {
+class UglyDucklingMk7 : public DeviceDefinition {
 public:
-    UglyDucklingMk7()
-        : DeviceDefinition<Mk7Config>(
-              pins::STATUS,
-              pins::BOOT) {
+    UglyDucklingMk7(shared_ptr<Mk7Config> config)
+        : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
     virtual std::shared_ptr<BatteryDriver> createBatteryDriver(I2CManager& i2c) override {

--- a/main/devices/UglyDucklingMk7.hpp
+++ b/main/devices/UglyDucklingMk7.hpp
@@ -101,7 +101,7 @@ public:
         peripheralManager.registerFactory(chickenDoorFactory);
     }
 
-    LedDriver secondaryStatusLed { "status-2", pins::STATUS2 };
+    shared_ptr<LedDriver> secondaryStatusLed { make_shared<LedDriver>("status-2", pins::STATUS2) };
 
     Drv8833Driver motorDriver {
         pwm,

--- a/main/devices/UglyDucklingMk7.hpp
+++ b/main/devices/UglyDucklingMk7.hpp
@@ -89,7 +89,11 @@ public:
     }
 
     static std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
-        return std::make_shared<Bq27220Driver>(i2c, pins::SDA, pins::SCL);
+        return std::make_shared<Bq27220Driver>(i2c, pins::SDA, pins::SCL, BatteryParameters {
+            .maximumVoltage = 4.1,
+            .bootThreshold = 3.7,
+            .shutdownThreshold = 3.0,
+        });
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {

--- a/main/devices/UglyDucklingMk7.hpp
+++ b/main/devices/UglyDucklingMk7.hpp
@@ -84,7 +84,7 @@ public:
 
 class UglyDucklingMk7 : public DeviceDefinition {
 public:
-    UglyDucklingMk7(shared_ptr<Mk7Config> config)
+    UglyDucklingMk7(std::shared_ptr<Mk7Config> config)
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
@@ -99,7 +99,7 @@ public:
         peripheralManager.registerFactory(chickenDoorFactory);
     }
 
-    shared_ptr<LedDriver> secondaryStatusLed { make_shared<LedDriver>("status-2", pins::STATUS2) };
+    std::shared_ptr<LedDriver> secondaryStatusLed { std::make_shared<LedDriver>("status-2", pins::STATUS2) };
 
     Drv8833Driver motorDriver {
         pwm,

--- a/main/devices/UglyDucklingMk7.hpp
+++ b/main/devices/UglyDucklingMk7.hpp
@@ -88,7 +88,7 @@ public:
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
-    virtual std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) override {
+    static std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {
         return std::make_shared<Bq27220Driver>(i2c, pins::SDA, pins::SCL);
     }
 

--- a/main/devices/UglyDucklingMk8.hpp
+++ b/main/devices/UglyDucklingMk8.hpp
@@ -27,12 +27,10 @@ public:
     }
 };
 
-class UglyDucklingMk8 : public DeviceDefinition<Mk8Config> {
+class UglyDucklingMk8 : public DeviceDefinition {
 public:
-    UglyDucklingMk8()
-        : DeviceDefinition<Mk8Config>(
-              pins::STATUS,
-              pins::BOOT) {
+    UglyDucklingMk8(shared_ptr<Mk8Config> config)
+        : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 
     void registerDeviceSpecificPeripheralFactories(PeripheralManager& peripheralManager) override {

--- a/main/devices/UglyDucklingMk8.hpp
+++ b/main/devices/UglyDucklingMk8.hpp
@@ -29,7 +29,7 @@ public:
 
 class UglyDucklingMk8 : public DeviceDefinition {
 public:
-    UglyDucklingMk8(shared_ptr<Mk8Config> config)
+    UglyDucklingMk8(std::shared_ptr<Mk8Config> config)
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 

--- a/main/kernel/BatteryManager.hpp
+++ b/main/kernel/BatteryManager.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <list>
+#include <memory>
+
+#include <esp_sleep.h>
+
+#include <kernel/MovingAverage.hpp>
+#include <kernel/ShutdownManager.hpp>
+#include <kernel/Task.hpp>
+#include <kernel/Telemetry.hpp>
+#include <kernel/drivers/BatteryDriver.hpp>
+
+using namespace farmhub::kernel::drivers;
+
+namespace farmhub::kernel {
+
+/**
+ * @brief Time to wait between battery checks.
+ */
+static constexpr microseconds LOW_POWER_SLEEP_CHECK_INTERVAL = 10s;
+
+[[noreturn]] inline void enterLowPowerDeepSleep() {
+    printf("Entering low power deep sleep\n");
+    esp_deep_sleep(duration_cast<microseconds>(LOW_POWER_SLEEP_CHECK_INTERVAL).count());
+    // Signal to the compiler that we are not returning for real
+    abort();
+}
+
+class BatteryManager : public TelemetryProvider {
+public:
+    BatteryManager(
+        std::shared_ptr<BatteryDriver> battery,
+        double batteryShutdownThreshold,
+        std::shared_ptr<ShutdownManager> shutdownManager)
+        : battery(battery)
+        , batteryShutdownThreshold(batteryShutdownThreshold)
+        , shutdownManager(shutdownManager) {
+        Task::loop("battery", 2560, [this](Task& task) {
+            checkBatteryVoltage(task);
+        });
+    }
+
+    void populateTelemetry(JsonObject& json) override {
+        auto voltage = batteryVoltage.getAverage();
+        if (voltage > 0) {
+            json["voltage"] = voltage;
+        }
+    }
+
+private:
+    void checkBatteryVoltage(Task& task) {
+        task.delayUntil(LOW_POWER_CHECK_INTERVAL);
+        auto currentVoltage = battery->getVoltage();
+        batteryVoltage.record(currentVoltage);
+        auto voltage = batteryVoltage.getAverage();
+
+        if (voltage != 0.0 && voltage < batteryShutdownThreshold) {
+            LOGI("Battery voltage low (%.2f V < %.2f), starting shutdown process, will go to deep sleep in %lld seconds",
+                voltage, batteryShutdownThreshold, duration_cast<seconds>(LOW_BATTERY_SHUTDOWN_TIMEOUT).count());
+
+            // TODO Publish all MQTT messages, then shut down WiFi, and _then_ start shutting down peripherals
+            //      Doing so would result in less of a power spike, which can be important if the battery is already low
+
+            shutdownManager->startShutdown();
+            Task::delay(LOW_BATTERY_SHUTDOWN_TIMEOUT);
+            enterLowPowerDeepSleep();
+        }
+    };
+
+    const std::shared_ptr<BatteryDriver> battery;
+    const double batteryShutdownThreshold;
+    const std::shared_ptr<ShutdownManager> shutdownManager;
+
+    MovingAverage<double> batteryVoltage { 5 };
+
+    /**
+     * @brief How often we check the battery voltage while in operation.
+     *
+     * We use a prime number to avoid synchronizing with other tasks.
+     */
+    static constexpr auto LOW_POWER_CHECK_INTERVAL = 10313ms;
+
+    /**
+     * @brief Time to wait for shutdown process to finish before going to deep sleep.
+     */
+    static constexpr auto LOW_BATTERY_SHUTDOWN_TIMEOUT = 10s;
+};
+
+}    // namespace farmhub::kernel

--- a/main/kernel/BatteryManager.hpp
+++ b/main/kernel/BatteryManager.hpp
@@ -39,8 +39,12 @@ public:
         });
     }
 
+    float getVoltage() {
+        return batteryVoltage.getAverage();
+    }
+
     void populateTelemetry(JsonObject& json) override {
-        auto voltage = batteryVoltage.getAverage();
+        auto voltage = getVoltage();
         if (voltage > 0) {
             json["voltage"] = voltage;
         }

--- a/main/kernel/Component.hpp
+++ b/main/kernel/Component.hpp
@@ -9,12 +9,12 @@ namespace farmhub::kernel {
 
 class Component : public Named {
 protected:
-    Component(const std::string& name, shared_ptr<MqttRoot> mqttRoot)
+    Component(const std::string& name, std::shared_ptr<MqttRoot> mqttRoot)
         : Named(name)
         , mqttRoot(mqttRoot) {
     }
 
-    shared_ptr<MqttRoot> mqttRoot;
+    std::shared_ptr<MqttRoot> mqttRoot;
 };
 
 }    // namespace farmhub::kernel

--- a/main/kernel/Concurrent.hpp
+++ b/main/kernel/Concurrent.hpp
@@ -46,16 +46,19 @@ public:
     }
 
     template <typename... Args>
+    requires std::constructible_from<TMessage, Args...>
     void put(Args&&... args) {
         while (!offerIn(ticks::max(), std::forward<Args>(args)...)) { }
     }
 
     template <typename... Args>
+    requires std::constructible_from<TMessage, Args...>
     bool offer(Args&&... args) {
         return offerIn(ticks::zero(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
+    requires std::constructible_from<TMessage, Args...>
     bool offerIn(ticks timeout, Args&&... args) {
         TMessage* copy = new TMessage(std::forward<Args>(args)...);
         bool sentWithoutDropping = xQueueSend(this->queue, &copy, timeout.count()) == pdTRUE;

--- a/main/kernel/Configuration.hpp
+++ b/main/kernel/Configuration.hpp
@@ -4,6 +4,7 @@
 #include <concepts>
 #include <functional>
 #include <list>
+#include <memory>
 
 #include <ArduinoJson.h>
 
@@ -139,17 +140,22 @@ class EmptyConfiguration : public ConfigurationSection { };
 template <std::derived_from<ConfigurationEntry> TDelegateEntry>
 class NamedConfigurationEntry : public ConfigurationEntry {
 public:
-    template <typename... Args>
-    NamedConfigurationEntry(ConfigurationSection* parent, const std::string& name, Args&&... args)
+    NamedConfigurationEntry(ConfigurationSection* parent, const std::string& name, std::shared_ptr<TDelegateEntry> delegate)
         : name(name)
-        , delegate(std::forward<Args>(args)...) {
+        , delegate(delegate) {
         parent->add(*this);
+    }
+
+    template <typename... Args>
+    requires std::constructible_from<TDelegateEntry, Args...>
+    NamedConfigurationEntry(ConfigurationSection* parent, const std::string& name, Args&&... args)
+        : NamedConfigurationEntry(parent, name, std::make_shared<TDelegateEntry>(std::forward<Args>(args)...)) {
     }
 
     void load(const JsonObject& json) override {
         if (json[name].is<JsonVariant>()) {
             namePresentAtLoad = true;
-            delegate.load(json[name]);
+            delegate->load(json[name]);
         } else {
             reset();
         }
@@ -158,26 +164,26 @@ public:
     void store(JsonObject& json, bool inlineDefaults) const override {
         if (inlineDefaults || hasValue()) {
             auto section = json[name].to<JsonObject>();
-            delegate.store(section, inlineDefaults);
+            delegate->store(section, inlineDefaults);
         }
     }
 
     bool hasValue() const override {
-        return namePresentAtLoad || delegate.hasValue();
+        return namePresentAtLoad || delegate->hasValue();
     }
 
     void reset() override {
         namePresentAtLoad = false;
-        delegate.reset();
+        delegate->reset();
     }
 
-    const TDelegateEntry& get() const {
+    const std::shared_ptr<TDelegateEntry> get() const {
         return delegate;
     }
 
 private:
     const std::string name;
-    TDelegateEntry delegate;
+    const std::shared_ptr<TDelegateEntry> delegate;
     bool namePresentAtLoad = false;
 };
 
@@ -279,8 +285,9 @@ private:
 template <std::derived_from<ConfigurationSection> TConfiguration>
 class ConfigurationFile {
 public:
-    ConfigurationFile(const FileSystem& fs, const std::string& path)
-        : path(path) {
+    ConfigurationFile(const FileSystem& fs, const std::string& path, std::shared_ptr<TConfiguration> config)
+        : path(path)
+        , config(config) {
         if (!fs.exists(path)) {
             LOGD("The configuration file '%s' was not found, falling back to defaults",
                 path.c_str());
@@ -317,11 +324,11 @@ public:
     }
 
     void reset() {
-        config.reset();
+        config->reset();
     }
 
     void update(const JsonObject& json) {
-        config.load(json);
+        config->load(json);
 
         for (auto& callback : callbacks) {
             callback(json);
@@ -333,7 +340,7 @@ public:
     }
 
     void store(JsonObject& json, bool inlineDefaults) const {
-        config.store(json, inlineDefaults);
+        config->store(json, inlineDefaults);
     }
 
     std::string toString(bool includeDefaults = true) {
@@ -345,10 +352,9 @@ public:
         return jsonString;
     }
 
-    TConfiguration config;
-
 private:
     const std::string path;
+    std::shared_ptr<TConfiguration> config;
     std::list<std::function<void(const JsonObject&)>> callbacks;
 };
 

--- a/main/kernel/DebugConsole.hpp
+++ b/main/kernel/DebugConsole.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <kernel/BatteryManager.hpp>
+#include <kernel/Strings.hpp>
+#include <kernel/drivers/RtcDriver.hpp>
+#include <kernel/drivers/WiFiDriver.hpp>
+
+using namespace farmhub::kernel::drivers;
+
+namespace farmhub::kernel {
+
+#ifdef FARMHUB_DEBUG
+class DebugConsole {
+public:
+    DebugConsole(const std::shared_ptr<BatteryManager> battery, WiFiDriver& wifi)
+        : battery(battery)
+        , wifi(wifi) {
+        status.reserve(256);
+        Task::loop("console", 3072, 1, [this](Task& task) {
+            printStatus();
+            task.delayUntilAtLeast(250ms);
+        });
+    }
+
+private:
+    void printStatus() {
+        static const char* spinner = "|/-\\";
+        static const int spinnerLength = strlen(spinner);
+        auto uptime = duration_cast<milliseconds>(boot_clock::now().time_since_epoch());
+
+        counter = (counter + 1) % spinnerLength;
+        status.clear();
+        status += "[" + std::string(1, spinner[counter]) + "] ";
+        status += "\033[33m" + std::string(farmhubVersion) + "\033[0m";
+        status += ", uptime: \033[33m" + toStringWithPrecision(uptime.count() / 1000.0f, 1) + "\033[0m s";
+        status += ", WIFI: " + std::string(wifiStatus()) + " (up \033[33m" + toStringWithPrecision(wifi.getUptime().count() / 1000.0f, 1) + "\033[0m s)";
+        status += ", RTC \033[33m" + std::string(RtcDriver::isTimeSet() ? "OK" : "UNSYNCED") + "\033[0m";
+        status += ", heap \033[33m" + toStringWithPrecision(heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0f, 2) + "\033[0m kB";
+        status += ", CPU: \033[33m" + std::to_string(esp_clk_cpu_freq() / 1000000) + "\033[0m MHz";
+
+        if (battery != nullptr) {
+            status += ", battery: \033[33m" + toStringWithPrecision(battery->getVoltage(), 2) + "\033[0m V";
+        }
+
+        printf("\033[1G\033[0K%s", status.c_str());
+        fflush(stdout);
+        fsync(fileno(stdout));
+    }
+
+    static const char* wifiStatus() {
+        auto netif = esp_netif_get_default_netif();
+        if (!netif) {
+            return "\033[0;33moff\033[0m";
+        }
+
+        wifi_mode_t mode;
+        ESP_ERROR_CHECK(esp_wifi_get_mode(&mode));
+
+        switch (mode) {
+            case WIFI_MODE_STA:
+                break;
+            case WIFI_MODE_NULL:
+                return "\033[0;33mNULL\033[0m";
+            case WIFI_MODE_AP:
+                return "\033[0;32mAP\033[0m";
+            case WIFI_MODE_APSTA:
+                return "\033[0;32mAPSTA\033[0m";
+            case WIFI_MODE_NAN:
+                return "\033[0;32mNAN\033[0m";
+            default:
+                return "\033[0;31m???\033[0m";
+        }
+
+        // Retrieve the current Wi-Fi station connection status
+        wifi_ap_record_t ap_info;
+        esp_err_t err = esp_wifi_sta_get_ap_info(&ap_info);
+        if (err != ESP_OK) {
+            return esp_err_to_name(err);
+        }
+
+        // Check IP address
+        esp_netif_ip_info_t ip_info;
+        err = esp_netif_get_ip_info(netif, &ip_info);
+        if (err != ESP_OK) {
+            return esp_err_to_name(err);
+        }
+
+        if (ip_info.ip.addr != 0) {
+            static char ip_str[32];
+            snprintf(ip_str, sizeof(ip_str), "\033[0;33m" IPSTR "\033[0m", IP2STR(&ip_info.ip));
+            return ip_str;
+        } else {
+            return "\033[0;33mIP?\033[0m";
+        }
+    }
+
+    int counter;
+    std::string status;
+    const std::shared_ptr<BatteryManager> battery;
+    WiFiDriver& wifi;
+};
+#endif
+
+}    // namespace farmhub::kernel

--- a/main/kernel/DebugConsole.hpp
+++ b/main/kernel/DebugConsole.hpp
@@ -12,7 +12,7 @@ namespace farmhub::kernel {
 #ifdef FARMHUB_DEBUG
 class DebugConsole {
 public:
-    DebugConsole(const std::shared_ptr<BatteryManager> battery, WiFiDriver& wifi)
+    DebugConsole(const std::shared_ptr<BatteryManager> battery, const std::shared_ptr<WiFiDriver> wifi)
         : battery(battery)
         , wifi(wifi) {
         status.reserve(256);
@@ -33,7 +33,7 @@ private:
         status += "[" + std::string(1, spinner[counter]) + "] ";
         status += "\033[33m" + std::string(farmhubVersion) + "\033[0m";
         status += ", uptime: \033[33m" + toStringWithPrecision(uptime.count() / 1000.0f, 1) + "\033[0m s";
-        status += ", WIFI: " + std::string(wifiStatus()) + " (up \033[33m" + toStringWithPrecision(wifi.getUptime().count() / 1000.0f, 1) + "\033[0m s)";
+        status += ", WIFI: " + std::string(wifiStatus()) + " (up \033[33m" + toStringWithPrecision(wifi->getUptime().count() / 1000.0f, 1) + "\033[0m s)";
         status += ", RTC \033[33m" + std::string(RtcDriver::isTimeSet() ? "OK" : "UNSYNCED") + "\033[0m";
         status += ", heap \033[33m" + toStringWithPrecision(heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024.0f, 2) + "\033[0m kB";
         status += ", CPU: \033[33m" + std::to_string(esp_clk_cpu_freq() / 1000000) + "\033[0m MHz";
@@ -94,10 +94,11 @@ private:
         }
     }
 
+    const std::shared_ptr<BatteryManager> battery;
+    const std::shared_ptr<WiFiDriver> wifi;
+
     int counter;
     std::string status;
-    const std::shared_ptr<BatteryManager> battery;
-    WiFiDriver& wifi;
 };
 #endif
 

--- a/main/kernel/HttpUpdate.hpp
+++ b/main/kernel/HttpUpdate.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <string>
+
+#include <ArduinoJson.h>
+
+#include <kernel/FileSystem.hpp>
+#include <kernel/Log.hpp>
+#include <kernel/PowerManager.hpp>
+#include <kernel/drivers/WiFiDriver.hpp>
+
+namespace farmhub::kernel {
+
+static constexpr const char* UPDATE_FILE = "/update.json";
+
+static esp_err_t httpEventHandler(esp_http_client_event_t* event) {
+    switch (event->event_id) {
+        case HTTP_EVENT_ERROR:
+            LOGE("HTTP error, status code: %d",
+                esp_http_client_get_status_code(event->client));
+            break;
+        case HTTP_EVENT_ON_CONNECTED:
+            LOGD("HTTP connected");
+            break;
+        case HTTP_EVENT_HEADERS_SENT:
+            LOGV("HTTP headers sent");
+            break;
+        case HTTP_EVENT_ON_HEADER:
+            LOGV("HTTP header: %s: %s", event->header_key, event->header_value);
+            break;
+        case HTTP_EVENT_ON_DATA:
+            LOGD("HTTP data: %d bytes", event->data_len);
+            break;
+        case HTTP_EVENT_ON_FINISH:
+            LOGD("HTTP finished");
+            break;
+        case HTTP_EVENT_DISCONNECTED:
+            LOGD("HTTP disconnected");
+            break;
+        default:
+            LOGW("Unknown HTTP event %d", event->event_id);
+            break;
+    }
+    return ESP_OK;
+}
+
+static std::string handleHttpUpdate(FileSystem& fs, std::shared_ptr<WiFiDriver> wifi) {
+    // Do we need to update?
+    if (!fs.exists(UPDATE_FILE)) {
+        // No update file, nothing to do
+        return "";
+    }
+
+    // Don't sleep while we are performing the update
+    PowerManagementLockGuard sleepLock(PowerManager::noLightSleep);
+
+    auto contents = fs.readAll(UPDATE_FILE);
+    if (!contents.has_value()) {
+        return "Failed to read update file";
+    }
+    JsonDocument doc;
+    auto error = deserializeJson(doc, contents.value());
+    int deleteError = fs.remove(UPDATE_FILE);
+    if (deleteError) {
+        return "Failed to delete update file";
+    }
+
+    if (error) {
+        return "Failed to parse update.json: " + std::string(error.c_str());
+    }
+    std::string url = doc["url"];
+    if (url.empty()) {
+        return "Command contains empty url";
+    }
+
+    LOGI("Updating from version %s via URL %s",
+        farmhubVersion, url.c_str());
+
+    LOGD("Waiting for network...");
+    if (!wifi->getNetworkReady().awaitSet(15s)) {
+        return "Network not ready, aborting update";
+    }
+
+    esp_http_client_config_t httpConfig = {
+        .url = url.c_str(),
+        .event_handler = httpEventHandler,
+        // Additional buffers to fit headers
+        // Updating directly via GitHub's release links requires these
+        .buffer_size = 4 * 1024,
+        .buffer_size_tx = 12 * 1024,
+        .user_data = nullptr,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+        .keep_alive_enable = true,
+    };
+    esp_https_ota_config_t otaConfig = {
+        .http_config = &httpConfig,
+    };
+    esp_err_t ret = esp_https_ota(&otaConfig);
+    if (ret == ESP_OK) {
+        LOGI("Update succeeded, rebooting in 5 seconds...");
+        Task::delay(5s);
+        esp_restart();
+    } else {
+        LOGE("Update failed (%s), continuing with regular boot",
+            esp_err_to_name(ret));
+        return std::string("Firmware upgrade failed: ") + esp_err_to_name(ret);
+    }
+}
+
+}    // namespace farmhub::kernel

--- a/main/kernel/HttpUpdate.hpp
+++ b/main/kernel/HttpUpdate.hpp
@@ -10,7 +10,6 @@
 
 #include <kernel/FileSystem.hpp>
 #include <kernel/Log.hpp>
-#include <kernel/PowerManager.hpp>
 #include <kernel/drivers/WiFiDriver.hpp>
 
 namespace farmhub::kernel {
@@ -54,9 +53,6 @@ static void handleHttpUpdate(FileSystem& fs, std::shared_ptr<WiFiDriver> wifi) {
         LOGV("No update file found, not updating");
         return;
     }
-
-    // Don't sleep while we are performing the update
-    PowerManagementLockGuard sleepLock(PowerManager::noLightSleep);
 
     auto contents = fs.readAll(UPDATE_FILE);
     if (!contents.has_value()) {

--- a/main/kernel/I2CManager.hpp
+++ b/main/kernel/I2CManager.hpp
@@ -10,8 +10,6 @@
 
 namespace farmhub::kernel {
 
-using std::shared_ptr;
-
 using farmhub::kernel::PinPtr;
 
 using GpioPair = std::pair<PinPtr, PinPtr>;
@@ -36,7 +34,7 @@ public:
 
 class I2CDevice {
 public:
-    I2CDevice(const std::string& name, shared_ptr<I2CBus> bus, uint8_t address)
+    I2CDevice(const std::string& name, std::shared_ptr<I2CBus> bus, uint8_t address)
         : name(name)
         , bus(bus)
         , address(address)
@@ -97,7 +95,7 @@ public:
 
 private:
     const std::string name;
-    const shared_ptr<I2CBus> bus;
+    const std::shared_ptr<I2CBus> bus;
     const uint8_t address;
     i2c_dev_t device;
 };
@@ -113,11 +111,11 @@ public:
         ESP_ERROR_CHECK(i2cdev_done());
     }
 
-    shared_ptr<I2CDevice> createDevice(const std::string& name, const I2CConfig& config) {
+    std::shared_ptr<I2CDevice> createDevice(const std::string& name, const I2CConfig& config) {
         return createDevice(name, config.sda, config.scl, config.address);
     }
 
-    shared_ptr<I2CDevice> createDevice(const std::string& name, InternalPinPtr sda, InternalPinPtr scl, uint8_t address) {
+    std::shared_ptr<I2CDevice> createDevice(const std::string& name, InternalPinPtr sda, InternalPinPtr scl, uint8_t address) {
         auto device = std::make_shared<I2CDevice>(name, getBusFor(sda, scl), address);
         LOGI("Created I2C device %s at address 0x%02x",
             name.c_str(), address);
@@ -130,11 +128,11 @@ public:
         return device;
     }
 
-    shared_ptr<I2CBus> getBusFor(const I2CConfig& config) {
+    std::shared_ptr<I2CBus> getBusFor(const I2CConfig& config) {
         return getBusFor(config.sda, config.scl);
     }
 
-    shared_ptr<I2CBus> getBusFor(InternalPinPtr sda, InternalPinPtr scl) {
+    std::shared_ptr<I2CBus> getBusFor(InternalPinPtr sda, InternalPinPtr scl) {
         Lock lock(mutex);
         for (auto bus : buses) {
             if (bus->sda == sda && bus->scl == scl) {
@@ -158,7 +156,7 @@ private:
     static constexpr size_t BUS_COUNT = 2;
 
     Mutex mutex;
-    std::vector<shared_ptr<I2CBus>> buses;
+    std::vector<std::shared_ptr<I2CBus>> buses;
 };
 
 }    // namespace farmhub::kernel

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -21,6 +21,7 @@
 #include <kernel/NetworkUtil.hpp>
 #include <kernel/PowerManager.hpp>
 #include <kernel/StateManager.hpp>
+#include <kernel/ShutdownManager.hpp>
 #include <kernel/Watchdog.hpp>
 #include <kernel/drivers/LedDriver.hpp>
 #include <kernel/drivers/MdnsDriver.hpp>
@@ -47,9 +48,11 @@ public:
         std::shared_ptr<DeviceConfiguration> deviceConfig,
         std::shared_ptr<MqttDriver::Config> mqttConfig,
         std::shared_ptr<LedDriver> statusLed,
+        std::shared_ptr<ShutdownManager> shutdownManager,
         std::shared_ptr<I2CManager> i2c)
         : version(farmhubVersion)
         , statusLed(statusLed)
+        , shutdownManager(shutdownManager)
         , powerManager(deviceConfig->sleepWhenIdle.get())
         , wifi(networkConnectingState, networkReadyState, configPortalRunningState, deviceConfig->getHostname(), deviceConfig->sleepWhenIdle.get())
         , mdns(networkReadyState, deviceConfig->getHostname(), "ugly-duckling", version, mdnsReadyState)
@@ -288,9 +291,11 @@ private:
         return ESP_OK;
     }
 
-    std::shared_ptr<LedDriver> statusLed;
+    const std::shared_ptr<LedDriver> statusLed;
 
 public:
+    const std::shared_ptr<ShutdownManager> shutdownManager;
+
     // TODO Make this configurable
     Watchdog watchdog { "watchdog", 5min, true, [](WatchdogState state) {
                            if (state == WatchdogState::TimedOut) {

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -5,9 +5,6 @@
 #include <functional>
 #include <optional>
 
-#include <esp_crt_bundle.h>
-#include <esp_http_client.h>
-#include <esp_https_ota.h>
 #include <esp_system.h>
 
 #include <nvs_flash.h>
@@ -17,7 +14,6 @@
 #include <devices/DeviceConfiguration.hpp>
 
 #include <kernel/FileSystem.hpp>
-#include <kernel/HttpUpdate.hpp>
 #include <kernel/I2CManager.hpp>
 #include <kernel/NetworkUtil.hpp>
 #include <kernel/PowerManager.hpp>
@@ -69,12 +65,6 @@ public:
 
         // TODO Allocate less memory when FARMHUB_DEBUG is disabled
         Task::loop("status-update", 3072, [this](Task&) { updateState(); });
-
-        httpUpdateResult = handleHttpUpdate(fs, wifi);
-        if (!httpUpdateResult.empty()) {
-            LOGE("HTTP update failed because: %s",
-                httpUpdateResult.c_str());
-        }
     }
 
     const State& getRtcInSyncState() const {

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -50,7 +50,7 @@ public:
         , wifi(networkConnectingState, networkReadyState, configPortalRunningState, deviceConfig->getHostname(), deviceConfig->sleepWhenIdle.get())
         , mdns(networkReadyState, deviceConfig->getHostname(), "ugly-duckling", version, mdnsReadyState)
         , rtc(networkReadyState, mdns, deviceConfig->ntp.get(), rtcInSyncState)
-        , mqtt(networkReadyState, mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState) {
+        , mqtt(std::make_shared<MqttDriver>(networkReadyState, mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState)) {
 
         LOGI("Initializing FarmHub kernel version %s on %s instance '%s' with hostname '%s' and MAC address %s",
             version.c_str(),
@@ -317,9 +317,9 @@ private:
     std::string httpUpdateResult;
 
 public:
-    MqttDriver mqtt;
-    SwitchManager switches;
-    I2CManager i2c;
+    const std::shared_ptr<MqttDriver> mqtt;
+    const std::shared_ptr<SwitchManager> switches = std::make_shared<SwitchManager>();
+    const std::shared_ptr<I2CManager> i2c = std::make_shared<I2CManager>();
 };
 
 }    // namespace farmhub::kernel

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -47,7 +47,8 @@ public:
         std::shared_ptr<I2CManager> i2c,
         std::shared_ptr<WiFiDriver> wifi,
         std::shared_ptr<MdnsDriver> mdns,
-        std::shared_ptr<RtcDriver> rtc)
+        std::shared_ptr<RtcDriver> rtc,
+        std::shared_ptr<MqttDriver> mqtt)
         : version(farmhubVersion)
         , statusLed(statusLed)
         , shutdownManager(shutdownManager)
@@ -55,7 +56,7 @@ public:
         , wifi(wifi)
         , mdns(mdns)
         , rtc(rtc)
-        , mqtt(std::make_shared<MqttDriver>(wifi->getNetworkReady(), mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState))
+        , mqtt(mqtt)
         , i2c(i2c) {
 
         LOGI("Initializing FarmHub kernel version %s on %s instance '%s' with hostname '%s' and MAC address %s",
@@ -141,7 +142,7 @@ private:
             newState = KernelState::NETWORK_CONNECTING;
         } else if (!rtc->getInSync().isSet()) {
             newState = KernelState::RTC_SYNCING;
-        } else if (!mqttReadyState.isSet()) {
+        } else if (!mqtt->getReady().isSet()) {
             // We are waiting for MQTT connection
             newState = KernelState::MQTT_CONNECTING;
         } else if (!kernelReadyState.isSet()) {
@@ -205,7 +206,6 @@ public:
 private:
     KernelState state = KernelState::BOOTING;
     StateManager stateManager;
-    StateSource mqttReadyState = stateManager.createStateSource("mqtt-ready");
     StateSource kernelReadyState = stateManager.createStateSource("kernel-ready");
 
 public:

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -17,6 +17,7 @@
 #include <devices/DeviceConfiguration.hpp>
 
 #include <kernel/FileSystem.hpp>
+#include <kernel/HttpUpdate.hpp>
 #include <kernel/I2CManager.hpp>
 #include <kernel/NetworkUtil.hpp>
 #include <kernel/PowerManager.hpp>
@@ -39,8 +40,6 @@ using namespace farmhub::kernel::mqtt;
 namespace farmhub::kernel {
 
 static RTC_DATA_ATTR int bootCount = 0;
-
-static constexpr const char* UPDATE_FILE = "/update.json";
 
 class Kernel {
 public:
@@ -71,7 +70,7 @@ public:
         // TODO Allocate less memory when FARMHUB_DEBUG is disabled
         Task::loop("status-update", 3072, [this](Task&) { updateState(); });
 
-        httpUpdateResult = handleHttpUpdate();
+        httpUpdateResult = handleHttpUpdate(fs, wifi);
         if (!httpUpdateResult.empty()) {
             LOGE("HTTP update failed because: %s",
                 httpUpdateResult.c_str());
@@ -194,98 +193,6 @@ private:
             };
         }
         stateManager.awaitStateChange();
-    }
-
-    std::string handleHttpUpdate() {
-        if (!fs.exists(UPDATE_FILE)) {
-            return "";
-        }
-
-        // Don't sleep while we are performing the update
-        PowerManagementLockGuard sleepLock(PowerManager::noLightSleep);
-
-        auto contents = fs.readAll(UPDATE_FILE);
-        if (!contents.has_value()) {
-            return "Failed to read update file";
-        }
-        JsonDocument doc;
-        auto error = deserializeJson(doc, contents.value());
-        int deleteError = fs.remove(UPDATE_FILE);
-        if (deleteError) {
-            return "Failed to delete update file";
-        }
-
-        if (error) {
-            return "Failed to parse update.json: " + std::string(error.c_str());
-        }
-        std::string url = doc["url"];
-        if (url.length() == 0) {
-            return "Command contains empty url";
-        }
-
-        LOGI("Updating from version %s via URL %s",
-            farmhubVersion, url.c_str());
-
-        LOGD("Waiting for network...");
-        if (!wifi->getNetworkReady().awaitSet(15s)) {
-            return "Network not ready, aborting update";
-        }
-
-        esp_http_client_config_t httpConfig = {
-            .url = url.c_str(),
-            .event_handler = httpEventHandler,
-            // Additional buffers to fit headers
-            // Updating directly via GitHub's release links requires these
-            .buffer_size = 4 * 1024,
-            .buffer_size_tx = 12 * 1024,
-            .user_data = this,
-            .crt_bundle_attach = esp_crt_bundle_attach,
-            .keep_alive_enable = true,
-        };
-        esp_https_ota_config_t otaConfig = {
-            .http_config = &httpConfig,
-        };
-        esp_err_t ret = esp_https_ota(&otaConfig);
-        if (ret == ESP_OK) {
-            LOGI("Update succeeded, rebooting in 5 seconds...");
-            Task::delay(5s);
-            esp_restart();
-        } else {
-            LOGE("Update failed (%s), continuing with regular boot",
-                esp_err_to_name(ret));
-            return std::string("Firmware upgrade failed: ") + esp_err_to_name(ret);
-        }
-    }    // namespace farmhub::kernel
-
-    static esp_err_t httpEventHandler(esp_http_client_event_t* event) {
-        switch (event->event_id) {
-            case HTTP_EVENT_ERROR:
-                LOGE("HTTP error, status code: %d",
-                    esp_http_client_get_status_code(event->client));
-                break;
-            case HTTP_EVENT_ON_CONNECTED:
-                LOGD("HTTP connected");
-                break;
-            case HTTP_EVENT_HEADERS_SENT:
-                LOGV("HTTP headers sent");
-                break;
-            case HTTP_EVENT_ON_HEADER:
-                LOGV("HTTP header: %s: %s", event->header_key, event->header_value);
-                break;
-            case HTTP_EVENT_ON_DATA:
-                LOGD("HTTP data: %d bytes", event->data_len);
-                break;
-            case HTTP_EVENT_ON_FINISH:
-                LOGD("HTTP finished");
-                break;
-            case HTTP_EVENT_DISCONNECTED:
-                LOGD("HTTP disconnected");
-                break;
-            default:
-                LOGW("Unknown HTTP event %d", event->event_id);
-                break;
-        }
-        return ESP_OK;
     }
 
     const std::shared_ptr<LedDriver> statusLed;

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -43,14 +43,19 @@ static constexpr const char* UPDATE_FILE = "/update.json";
 
 class Kernel {
 public:
-    Kernel(std::shared_ptr<DeviceConfiguration> deviceConfig, std::shared_ptr<MqttDriver::Config> mqttConfig, std::shared_ptr<LedDriver> statusLed)
+    Kernel(
+        std::shared_ptr<DeviceConfiguration> deviceConfig,
+        std::shared_ptr<MqttDriver::Config> mqttConfig,
+        std::shared_ptr<LedDriver> statusLed,
+        std::shared_ptr<I2CManager> i2c)
         : version(farmhubVersion)
         , statusLed(statusLed)
         , powerManager(deviceConfig->sleepWhenIdle.get())
         , wifi(networkConnectingState, networkReadyState, configPortalRunningState, deviceConfig->getHostname(), deviceConfig->sleepWhenIdle.get())
         , mdns(networkReadyState, deviceConfig->getHostname(), "ugly-duckling", version, mdnsReadyState)
         , rtc(networkReadyState, mdns, deviceConfig->ntp.get(), rtcInSyncState)
-        , mqtt(std::make_shared<MqttDriver>(networkReadyState, mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState)) {
+        , mqtt(std::make_shared<MqttDriver>(networkReadyState, mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState))
+        , i2c(i2c) {
 
         LOGI("Initializing FarmHub kernel version %s on %s instance '%s' with hostname '%s' and MAC address %s",
             version.c_str(),
@@ -319,7 +324,7 @@ private:
 public:
     const std::shared_ptr<MqttDriver> mqtt;
     const std::shared_ptr<SwitchManager> switches = std::make_shared<SwitchManager>();
-    const std::shared_ptr<I2CManager> i2c = std::make_shared<I2CManager>();
+    const std::shared_ptr<I2CManager> i2c;
 };
 
 }    // namespace farmhub::kernel

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -52,7 +52,6 @@ public:
         : version(farmhubVersion)
         , statusLed(statusLed)
         , shutdownManager(shutdownManager)
-        , powerManager(deviceConfig->sleepWhenIdle.get())
         , wifi(wifi)
         , mdns(mdns)
         , rtc(rtc)
@@ -200,8 +199,6 @@ public:
                                esp_system_abort("Watchdog timed out");
                            }
                        } };
-
-    PowerManager powerManager;
 
 private:
     KernelState state = KernelState::BOOTING;

--- a/main/kernel/Kernel.hpp
+++ b/main/kernel/Kernel.hpp
@@ -45,13 +45,14 @@ public:
         std::shared_ptr<LedDriver> statusLed,
         std::shared_ptr<ShutdownManager> shutdownManager,
         std::shared_ptr<I2CManager> i2c,
-        std::shared_ptr<WiFiDriver> wifi)
+        std::shared_ptr<WiFiDriver> wifi,
+        std::shared_ptr<MdnsDriver> mdns)
         : version(farmhubVersion)
         , statusLed(statusLed)
         , shutdownManager(shutdownManager)
         , powerManager(deviceConfig->sleepWhenIdle.get())
         , wifi(wifi)
-        , mdns(wifi->getNetworkReady(), deviceConfig->getHostname(), "ugly-duckling", version, mdnsReadyState)
+        , mdns(mdns)
         , rtc(wifi->getNetworkReady(), mdns, deviceConfig->ntp.get(), rtcInSyncState)
         , mqtt(std::make_shared<MqttDriver>(wifi->getNetworkReady(), mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState))
         , i2c(i2c) {
@@ -204,7 +205,6 @@ private:
     KernelState state = KernelState::BOOTING;
     StateManager stateManager;
     StateSource rtcInSyncState = stateManager.createStateSource("rtc-in-sync");
-    StateSource mdnsReadyState = stateManager.createStateSource("mdns-ready");
     StateSource mqttReadyState = stateManager.createStateSource("mqtt-ready");
     StateSource kernelReadyState = stateManager.createStateSource("kernel-ready");
 
@@ -212,7 +212,7 @@ public:
     const std::shared_ptr<WiFiDriver> wifi;
 
 private:
-    MdnsDriver mdns;
+    const std::shared_ptr<MdnsDriver> mdns;
     RtcDriver rtc;
 
     std::string httpUpdateResult;

--- a/main/kernel/Log.hpp
+++ b/main/kernel/Log.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include <ArduinoJson.h>
 
 #include <esp_log.h>
@@ -14,6 +16,11 @@ enum class Level {
     Info = 4,
     Debug = 5,
     Verbose = 6,
+};
+
+struct LogRecord {
+    const Level level;
+    const std::string message;
 };
 
 class Tag {

--- a/main/kernel/MovingAverage.hpp
+++ b/main/kernel/MovingAverage.hpp
@@ -4,7 +4,7 @@
 
 namespace farmhub::kernel {
 
-template <typename T>
+template <std::floating_point T>
 class MovingAverage {
 public:
     explicit MovingAverage(std::size_t maxMeasurements)

--- a/main/kernel/NetworkUtil.hpp
+++ b/main/kernel/NetworkUtil.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+#include <esp_mac.h>
+
+namespace farmhub::kernel {
+
+static const std::string& getMacAddress() {
+    static std::string macAddress;
+    if (macAddress.length() == 0) {
+        uint8_t rawMac[6];
+        for (int i = 0; i < 6; i++) {
+            rawMac[i] = 0;
+        }
+        if (esp_read_mac(rawMac, ESP_MAC_WIFI_STA) != ESP_OK) {
+            macAddress = "??:??:??:??:??:??:??:??";
+        } else {
+            char mac[24];
+            sprintf(mac, "%02x:%02x:%02x:%02x:%02x:%02x",
+                rawMac[0], rawMac[1], rawMac[2], rawMac[3],
+                rawMac[4], rawMac[5]);
+            macAddress = mac;
+        }
+    }
+    return macAddress;
+}
+
+}    // namespace farmhub::kernel

--- a/main/kernel/PcntManager.hpp
+++ b/main/kernel/PcntManager.hpp
@@ -46,7 +46,7 @@ private:
 
 class PcntManager {
 public:
-    shared_ptr<PulseCounterUnit> registerUnit(InternalPinPtr pin, nanoseconds maxGlitchDuration = 1000ns) {
+    std::shared_ptr<PulseCounterUnit> registerUnit(InternalPinPtr pin, nanoseconds maxGlitchDuration = 1000ns) {
         pcnt_unit_config_t unitConfig = {
             .low_limit = std::numeric_limits<int16_t>::min(),
             .high_limit = std::numeric_limits<int16_t>::max(),
@@ -76,7 +76,7 @@ public:
 
         LOGTD(Tag::PCNT, "Registered PCNT unit on pin %s",
             pin->getName().c_str());
-        return make_shared<PulseCounterUnit>(unit, pin);
+        return std::make_shared<PulseCounterUnit>(unit, pin);
     }
 };
 

--- a/main/kernel/ShutdownManager.hpp
+++ b/main/kernel/ShutdownManager.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <functional>
+#include <list>
+
+#include <kernel/Task.hpp>
+
+namespace farmhub::kernel {
+
+class ShutdownManager {
+public:
+    void registerShutdownListener(std::function<void()> listener) {
+        shutdownListeners.push_back(listener);
+    }
+
+    void startShutdown() {
+        // Run in separate task to allocate enough stack
+        Task::run("shutdown", 8192, [&](Task& task) {
+            // Notify all shutdown listeners
+            for (auto& listener : shutdownListeners) {
+                listener();
+            }
+            printf("Shutdown process finished\n");
+        });
+    }
+
+private:
+    std::list<std::function<void()>> shutdownListeners;
+};
+
+}    // namespace farmhub::kernel

--- a/main/kernel/Task.hpp
+++ b/main/kernel/Task.hpp
@@ -6,6 +6,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
+#include <kernel/Log.hpp>
 #include <kernel/Time.hpp>
 
 using namespace std::chrono;

--- a/main/kernel/Telemetry.hpp
+++ b/main/kernel/Telemetry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 
 #include <ArduinoJson.h>

--- a/main/kernel/drivers/BatteryDriver.hpp
+++ b/main/kernel/drivers/BatteryDriver.hpp
@@ -10,16 +10,36 @@ using farmhub::kernel::PinPtr;
 
 namespace farmhub::kernel::drivers {
 
+struct BatteryParameters {
+    const float maximumVoltage;
+    /**
+     * @brief Do not boot if battery is below this threshold.
+     */
+    const float bootThreshold;
+
+    /**
+     * @brief Shutdown if battery drops below this threshold.
+     */
+    const float shutdownThreshold;
+};
+
 class BatteryDriver {
 public:
+    BatteryDriver(const BatteryParameters& parameters)
+        : parameters(parameters) {
+    }
+
     virtual float getVoltage() = 0;
+
+    const BatteryParameters parameters;
 };
 
 class AnalogBatteryDriver
     : public BatteryDriver {
 public:
-    AnalogBatteryDriver(InternalPinPtr pin, float voltageDividerRatio)
-        : analogPin(pin)
+    AnalogBatteryDriver(InternalPinPtr pin, float voltageDividerRatio, const BatteryParameters& parameters)
+        : BatteryDriver(parameters)
+        , analogPin(pin)
         , voltageDividerRatio(voltageDividerRatio) {
         LOGI("Initializing analog battery driver on pin %s",
             analogPin.getName().c_str());

--- a/main/kernel/drivers/BatteryDriver.hpp
+++ b/main/kernel/drivers/BatteryDriver.hpp
@@ -10,26 +10,9 @@ using farmhub::kernel::PinPtr;
 
 namespace farmhub::kernel::drivers {
 
-/**
- * @brief Time to wait between battery checks.
- */
-static constexpr microseconds LOW_POWER_SLEEP_CHECK_INTERVAL = 10s;
-
-[[noreturn]] inline void enterLowPowerDeepSleep() {
-    printf("Entering low power deep sleep\n");
-    esp_deep_sleep(duration_cast<microseconds>(LOW_POWER_SLEEP_CHECK_INTERVAL).count());
-    // Signal to the compiler that we are not returning for real
-    abort();
-}
-
-class BatteryDriver : public TelemetryProvider {
+class BatteryDriver {
 public:
     virtual float getVoltage() = 0;
-
-protected:
-    virtual void populateTelemetry(JsonObject& json) override {
-        json["voltage"] = getVoltage();
-    }
 };
 
 class AnalogBatteryDriver

--- a/main/kernel/drivers/BatteryDriver.hpp
+++ b/main/kernel/drivers/BatteryDriver.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <limits>
 
 #include <kernel/Pin.hpp>
@@ -8,6 +9,18 @@
 using farmhub::kernel::PinPtr;
 
 namespace farmhub::kernel::drivers {
+
+/**
+ * @brief Time to wait between battery checks.
+ */
+static constexpr microseconds LOW_POWER_SLEEP_CHECK_INTERVAL = 10s;
+
+[[noreturn]] inline void enterLowPowerDeepSleep() {
+    printf("Entering low power deep sleep\n");
+    esp_deep_sleep(duration_cast<microseconds>(LOW_POWER_SLEEP_CHECK_INTERVAL).count());
+    // Signal to the compiler that we are not returning for real
+    abort();
+}
 
 class BatteryDriver : public TelemetryProvider {
 public:

--- a/main/kernel/drivers/Bq27220Driver.hpp
+++ b/main/kernel/drivers/Bq27220Driver.hpp
@@ -38,15 +38,15 @@ public:
         return device->readRegWord(0x06) * 0.1 - 273.2;
     }
 
-protected:
-    void populateTelemetry(JsonObject& json) override {
-        BatteryDriver::populateTelemetry(json);
-        json["current"] = getCurrent();
-        auto status = device->readRegWord(0x0A);
-        json["status"] = status;
-        json["charging"] = (status & 0x0001) == 0;
-        json["temperature"] = getTemperature();
-    }
+// protected:
+//     void populateTelemetry(JsonObject& json) override {
+//         BatteryDriver::populateTelemetry(json);
+//         json["current"] = getCurrent();
+//         auto status = device->readRegWord(0x0A);
+//         json["status"] = status;
+//         json["charging"] = (status & 0x0001) == 0;
+//         json["temperature"] = getTemperature();
+//     }
 
 private:
     int16_t readSigned(uint8_t reg) {

--- a/main/kernel/drivers/Bq27220Driver.hpp
+++ b/main/kernel/drivers/Bq27220Driver.hpp
@@ -9,8 +9,8 @@ namespace farmhub::kernel::drivers {
 
 class Bq27220Driver : public BatteryDriver {
 public:
-    Bq27220Driver(I2CManager& i2c, InternalPinPtr sda, InternalPinPtr scl, const uint8_t address = 0x55)
-        : device(i2c.createDevice("battery:bq27220", sda, scl, address)) {
+    Bq27220Driver(std::shared_ptr<I2CManager> i2c, InternalPinPtr sda, InternalPinPtr scl, const uint8_t address = 0x55)
+        : device(i2c->createDevice("battery:bq27220", sda, scl, address)) {
         LOGI("Initializing BQ27220 driver on SDA %s, SCL %s",
             sda->getName().c_str(), scl->getName().c_str());
 

--- a/main/kernel/drivers/Bq27220Driver.hpp
+++ b/main/kernel/drivers/Bq27220Driver.hpp
@@ -9,8 +9,13 @@ namespace farmhub::kernel::drivers {
 
 class Bq27220Driver : public BatteryDriver {
 public:
-    Bq27220Driver(std::shared_ptr<I2CManager> i2c, InternalPinPtr sda, InternalPinPtr scl, const uint8_t address = 0x55)
-        : device(i2c->createDevice("battery:bq27220", sda, scl, address)) {
+    Bq27220Driver(std::shared_ptr<I2CManager> i2c, InternalPinPtr sda, InternalPinPtr scl, const BatteryParameters& parameters)
+        : Bq27220Driver(i2c, sda, scl, 0x55, parameters) {
+    }
+
+    Bq27220Driver(std::shared_ptr<I2CManager> i2c, InternalPinPtr sda, InternalPinPtr scl, const uint8_t address, const BatteryParameters& parameters)
+        : BatteryDriver(parameters)
+        , device(i2c->createDevice("battery:bq27220", sda, scl, address)) {
         LOGI("Initializing BQ27220 driver on SDA %s, SCL %s",
             sda->getName().c_str(), scl->getName().c_str());
 
@@ -38,15 +43,15 @@ public:
         return device->readRegWord(0x06) * 0.1 - 273.2;
     }
 
-// protected:
-//     void populateTelemetry(JsonObject& json) override {
-//         BatteryDriver::populateTelemetry(json);
-//         json["current"] = getCurrent();
-//         auto status = device->readRegWord(0x0A);
-//         json["status"] = status;
-//         json["charging"] = (status & 0x0001) == 0;
-//         json["temperature"] = getTemperature();
-//     }
+    // protected:
+    //     void populateTelemetry(JsonObject& json) override {
+    //         BatteryDriver::populateTelemetry(json);
+    //         json["current"] = getCurrent();
+    //         auto status = device->readRegWord(0x0A);
+    //         json["status"] = status;
+    //         json["charging"] = (status & 0x0001) == 0;
+    //         json["temperature"] = getTemperature();
+    //     }
 
 private:
     int16_t readSigned(uint8_t reg) {

--- a/main/kernel/drivers/Bq27220Driver.hpp
+++ b/main/kernel/drivers/Bq27220Driver.hpp
@@ -58,7 +58,7 @@ private:
         return device->readRegByte(0x40) | (device->readRegByte(0x41) << 8);
     }
 
-    shared_ptr<I2CDevice> device;
+    std::shared_ptr<I2CDevice> device;
 };
 
 }    // namespace farmhub::kernel::drivers

--- a/main/kernel/drivers/Drv8801Driver.hpp
+++ b/main/kernel/drivers/Drv8801Driver.hpp
@@ -25,7 +25,7 @@ private:
 public:
     // Note: on Ugly Duckling MK5, the DRV8874's PMODE is wired to 3.3V, so it's locked in PWM mode
     Drv8801Driver(
-        PwmManager& pwm,
+        std::shared_ptr<PwmManager> pwm,
         PinPtr enablePin,
         InternalPinPtr phasePin,
         PinPtr mode1Pin,
@@ -34,7 +34,7 @@ public:
         PinPtr faultPin,
         PinPtr sleepPin)
         : enablePin(enablePin)
-        , phaseChannel(pwm.registerPin(phasePin, PWM_FREQ, PWM_RESOLUTION))
+        , phaseChannel(pwm->registerPin(phasePin, PWM_FREQ, PWM_RESOLUTION))
         , currentPin(currentPin)
         , faultPin(faultPin)
         , sleepPin(sleepPin) {

--- a/main/kernel/drivers/Drv8833Driver.hpp
+++ b/main/kernel/drivers/Drv8833Driver.hpp
@@ -20,7 +20,7 @@ class Drv8833Driver {
 public:
     // Note: on Ugly Duckling MK5, the DRV8874's PMODE is wired to 3.3V, so it's locked in PWM mode
     Drv8833Driver(
-        PwmManager& pwm,
+        std::shared_ptr<PwmManager> pwm,
         InternalPinPtr ain1Pin,
         InternalPinPtr ain2Pin,
         InternalPinPtr bin1Pin,
@@ -65,13 +65,13 @@ private:
     public:
         Drv8833MotorDriver(
             Drv8833Driver* driver,
-            PwmManager& pwm,
+            std::shared_ptr<PwmManager> pwm,
             InternalPinPtr in1Pin,
             InternalPinPtr in2Pin,
             bool canSleep)
             : driver(driver)
-            , in1Channel(pwm.registerPin(in1Pin, PWM_FREQ, PWM_RESOLUTION))
-            , in2Channel(pwm.registerPin(in2Pin, PWM_FREQ, PWM_RESOLUTION))
+            , in1Channel(pwm->registerPin(in1Pin, PWM_FREQ, PWM_RESOLUTION))
+            , in2Channel(pwm->registerPin(in2Pin, PWM_FREQ, PWM_RESOLUTION))
             , sleeping(canSleep) {
         }
 

--- a/main/kernel/drivers/Drv8874Driver.hpp
+++ b/main/kernel/drivers/Drv8874Driver.hpp
@@ -25,14 +25,14 @@ private:
 public:
     // Note: on Ugly Duckling MK5, the DRV8874's PMODE is wired to 3.3V, so it's locked in PWM mode
     Drv8874Driver(
-        PwmManager& pwm,
+        std::shared_ptr<PwmManager> pwm,
         InternalPinPtr in1Pin,
         InternalPinPtr in2Pin,
         PinPtr currentPin,
         PinPtr faultPin,
         PinPtr sleepPin)
-        : in1Channel(pwm.registerPin(in1Pin, PWM_FREQ, PWM_RESOLUTION))
-        , in2Channel(pwm.registerPin(in2Pin, PWM_FREQ, PWM_RESOLUTION))
+        : in1Channel(pwm->registerPin(in1Pin, PWM_FREQ, PWM_RESOLUTION))
+        , in2Channel(pwm->registerPin(in2Pin, PWM_FREQ, PWM_RESOLUTION))
         , currentPin(currentPin)
         , faultPin(faultPin)
         , sleepPin(sleepPin) {

--- a/main/kernel/drivers/MdnsDriver.hpp
+++ b/main/kernel/drivers/MdnsDriver.hpp
@@ -92,6 +92,10 @@ public:
         return result;
     }
 
+    State& getMdnsReady() {
+        return mdnsReady;
+    }
+
 private:
     bool lookupServiceUnderMutex(const std::string& serviceName, const std::string& port, MdnsRecord& record, bool loadFromCache, milliseconds timeout) {
         // TODO Use a callback and retry if cached entry doesn't work

--- a/main/kernel/drivers/RtcDriver.hpp
+++ b/main/kernel/drivers/RtcDriver.hpp
@@ -35,7 +35,7 @@ public:
         Property<std::string> host { this, "host", "" };
     };
 
-    RtcDriver(State& networkReady, MdnsDriver& mdns, const Config& ntpConfig, StateSource& rtcInSync)
+    RtcDriver(State& networkReady, MdnsDriver& mdns, const std::shared_ptr<Config> ntpConfig, StateSource& rtcInSync)
         : networkReady(networkReady)
         , mdns(mdns)
         , ntpConfig(ntpConfig)
@@ -91,10 +91,10 @@ private:
         LOGTI(Tag::RTC, "using default NTP server for Wokwi");
 #else
         // TODO Check this
-        if (ntpConfig.host.get().length() > 0) {
+        if (ntpConfig->host.get().length() > 0) {
             LOGTD(Tag::RTC, "using NTP server %s from configuration",
-                ntpConfig.host.get().c_str());
-            esp_sntp_setservername(0, ntpConfig.host.get().c_str());
+                ntpConfig->host.get().c_str());
+            esp_sntp_setservername(0, ntpConfig->host.get().c_str());
         } else {
             MdnsRecord ntpServer;
             if (mdns.lookupService("ntp", "udp", ntpServer, trustMdnsCache)) {
@@ -146,7 +146,7 @@ private:
 
     State& networkReady;
     MdnsDriver& mdns;
-    const Config& ntpConfig;
+    const std::shared_ptr<Config> ntpConfig;
     StateSource& rtcInSync;
 
     bool trustMdnsCache = true;

--- a/main/kernel/drivers/RtcDriver.hpp
+++ b/main/kernel/drivers/RtcDriver.hpp
@@ -76,6 +76,10 @@ public:
         return now > limit;
     }
 
+    State& getInSync() {
+        return rtcInSync;
+    }
+
 private:
     bool updateTime() {
         esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");

--- a/main/kernel/drivers/RtcDriver.hpp
+++ b/main/kernel/drivers/RtcDriver.hpp
@@ -35,7 +35,7 @@ public:
         Property<std::string> host { this, "host", "" };
     };
 
-    RtcDriver(State& networkReady, MdnsDriver& mdns, const std::shared_ptr<Config> ntpConfig, StateSource& rtcInSync)
+    RtcDriver(State& networkReady, std::shared_ptr<MdnsDriver> mdns, const std::shared_ptr<Config> ntpConfig, StateSource& rtcInSync)
         : networkReady(networkReady)
         , mdns(mdns)
         , ntpConfig(ntpConfig)
@@ -97,7 +97,7 @@ private:
             esp_sntp_setservername(0, ntpConfig->host.get().c_str());
         } else {
             MdnsRecord ntpServer;
-            if (mdns.lookupService("ntp", "udp", ntpServer, trustMdnsCache)) {
+            if (mdns->lookupService("ntp", "udp", ntpServer, trustMdnsCache)) {
                 LOGTD(Tag::RTC, "using NTP server %s from mDNS",
                     ntpServer.toString().c_str());
                 esp_sntp_setserver(0, (const ip_addr_t*) &ntpServer.ip);
@@ -145,7 +145,7 @@ private:
     }
 
     State& networkReady;
-    MdnsDriver& mdns;
+    const std::shared_ptr<MdnsDriver> mdns;
     const std::shared_ptr<Config> ntpConfig;
     StateSource& rtcInSync;
 

--- a/main/kernel/drivers/WiFiDriver.hpp
+++ b/main/kernel/drivers/WiFiDriver.hpp
@@ -21,7 +21,12 @@ namespace farmhub::kernel::drivers {
 
 class WiFiDriver {
 public:
-    WiFiDriver(StateSource& networkConnecting, StateSource& networkReady, StateSource& configPortalRunning, const std::string& hostname, bool powerSaveMode)
+    WiFiDriver(
+        StateSource& networkConnecting,
+        StateSource& networkReady,
+        StateSource& configPortalRunning,
+        const std::string& hostname,
+        bool powerSaveMode)
         : networkConnecting(networkConnecting)
         , networkReady(networkReady)
         , configPortalRunning(configPortalRunning)
@@ -67,6 +72,18 @@ public:
 
     milliseconds getUptime() {
         return wifiUptimeBefore + currentWifiUptime();
+    }
+
+    State& getNetworkConnecting() {
+        return networkConnecting;
+    }
+
+    State& getNetworkReady() {
+        return networkReady;
+    }
+
+    State& getConfigPortalRunning() {
+        return configPortalRunning;
     }
 
 private:

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -68,7 +68,7 @@ public:
 
     MqttDriver(
         State& networkReady,
-        MdnsDriver& mdns,
+        std::shared_ptr<MdnsDriver> mdns,
         const std::shared_ptr<Config> config,
         const std::string& instanceName,
         bool powerSaveMode,
@@ -108,7 +108,7 @@ public:
             port = 1883;
 #else
             MdnsRecord mqttServer;
-            while (!mdns.lookupService("mqtt", "tcp", mqttServer, trustMdnsCache)) {
+            while (!mdns->lookupService("mqtt", "tcp", mqttServer, trustMdnsCache)) {
                 LOGTE(Tag::MQTT, "Failed to lookup MQTT server from mDNS");
                 trustMdnsCache = false;
                 Task::delay(5s);
@@ -690,7 +690,7 @@ private:
     }
 
     State& networkReady;
-    MdnsDriver& mdns;
+    const std::shared_ptr<MdnsDriver> mdns;
     bool trustMdnsCache = true;
 
     const std::string configHostname;

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -19,9 +19,6 @@
 
 using namespace std::chrono_literals;
 using namespace farmhub::kernel;
-using std::make_shared;
-using std::shared_ptr;
-
 using namespace farmhub::kernel::drivers;
 
 namespace farmhub::kernel::mqtt {
@@ -167,8 +164,8 @@ public:
         }
     }
 
-    shared_ptr<MqttRoot> forRoot(const std::string& topic) {
-        return make_shared<MqttRoot>(*this, topic);
+    std::shared_ptr<MqttRoot> forRoot(const std::string& topic) {
+        return std::make_shared<MqttRoot>(*this, topic);
     }
 
     // TODO Review these values

--- a/main/kernel/mqtt/MqttDriver.hpp
+++ b/main/kernel/mqtt/MqttDriver.hpp
@@ -72,22 +72,22 @@ public:
     MqttDriver(
         State& networkReady,
         MdnsDriver& mdns,
-        const Config& config,
+        const std::shared_ptr<Config> config,
         const std::string& instanceName,
         bool powerSaveMode,
         StateSource& mqttReady)
         : networkReady(networkReady)
         , mdns(mdns)
-        , configHostname(config.host.get())
-        , configPort(config.port.get())
-        , configServerCert(joinStrings(config.serverCert.get()))
-        , configClientCert(joinStrings(config.clientCert.get()))
-        , configClientKey(joinStrings(config.clientKey.get()))
-        , clientId(getClientId(config.clientId.get(), instanceName))
+        , configHostname(config->host.get())
+        , configPort(config->port.get())
+        , configServerCert(joinStrings(config->serverCert.get()))
+        , configClientCert(joinStrings(config->clientCert.get()))
+        , configClientKey(joinStrings(config->clientKey.get()))
+        , clientId(getClientId(config->clientId.get(), instanceName))
         , powerSaveMode(powerSaveMode)
         , mqttReady(mqttReady)
-        , eventQueue("mqtt-outgoing", config.queueSize.get())
-        , incomingQueue("mqtt-incoming", config.queueSize.get()) {
+        , eventQueue("mqtt-outgoing", config->queueSize.get())
+        , incomingQueue("mqtt-incoming", config->queueSize.get()) {
 
         Task::run("mqtt", 5120, [this](Task& task) {
             configMqttClient(mqttConfig);

--- a/main/kernel/mqtt/MqttRoot.hpp
+++ b/main/kernel/mqtt/MqttRoot.hpp
@@ -13,8 +13,8 @@ public:
         , rootTopic(rootTopic) {
     }
 
-    shared_ptr<MqttRoot> forSuffix(const std::string& suffix) {
-        return make_shared<MqttRoot>(mqtt, rootTopic + "/" + suffix);
+    std::shared_ptr<MqttRoot> forSuffix(const std::string& suffix) {
+        return std::make_shared<MqttRoot>(mqtt, rootTopic + "/" + suffix);
     }
 
     PublishStatus publish(const std::string& suffix, const JsonDocument& json, Retention retain = Retention::NoRetain, QoS qos = QoS::AtMostOnce, ticks timeout = MqttDriver::MQTT_DEFAULT_PUBLISH_TIMEOUT, LogPublish log = LogPublish::Log) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -14,7 +14,10 @@ static const char* const farmhubVersion = esp_app_get_description()->version;
 
 #include <kernel/BatteryManager.hpp>
 #include <kernel/Console.hpp>
+#include <kernel/HttpUpdate.hpp>
 #include <kernel/Log.hpp>
+
+using namespace farmhub::kernel;
 
 #ifdef CONFIG_HEAP_TRACING
 #include <esp_heap_trace.h>
@@ -148,7 +151,8 @@ extern "C" void app_main() {
 
     auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);
 
-    // TODO Handle HTTP update here
+    // Reboots if update is successful
+    handleHttpUpdate(fs, wifi);
 
     auto shutdownManager = std::make_shared<ShutdownManager>();
     std::shared_ptr<BatteryManager> batteryManager;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -101,7 +101,7 @@ extern "C" void app_main() {
 #endif
 
     auto deviceDefinition = std::make_shared<TDeviceDefinition>();
-    auto kernel = std::make_shared<Kernel<TDeviceConfiguration>>(deviceDefinition->config, deviceDefinition->mqttConfig, deviceDefinition->statusLed);
+    auto kernel = std::make_shared<Kernel>(deviceDefinition->config, deviceDefinition->mqttConfig, deviceDefinition->statusLed);
 
     new farmhub::devices::Device(deviceDefinition, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -85,13 +85,13 @@ extern "C" void app_main() {
     auto i2c = std::make_shared<I2CManager>();
     auto battery = TDeviceDefinition::createBatteryDriver(i2c);
     if (battery != nullptr) {
-        // If the battery voltage is below threshold, we should not boot yet.
+        // If the battery voltage is below the device's threshold, we should not boot yet.
         // This is to prevent the device from booting and immediately shutting down
         // due to the high current draw of the boot process.
         auto voltage = battery->getVoltage();
-        if (voltage != 0.0 && voltage < BATTERY_BOOT_THRESHOLD) {
+        if (voltage != 0.0 && voltage < battery->parameters.bootThreshold) {
             ESP_LOGW("battery", "Battery voltage too low (%.2f V < %.2f), entering deep sleep\n",
-                voltage, BATTERY_BOOT_THRESHOLD);
+                voltage, battery->parameters.bootThreshold);
             enterLowPowerDeepSleep();
         }
     }
@@ -129,7 +129,7 @@ extern "C" void app_main() {
     auto shutdownManager = std::make_shared<ShutdownManager>();
     std::shared_ptr<BatteryManager> batteryManager;
     if (battery != nullptr) {
-        batteryManager = std::make_shared<BatteryManager>(battery, BATTERY_SHUTDOWN_THRESHOLD, shutdownManager);
+        batteryManager = std::make_shared<BatteryManager>(battery, shutdownManager);
     }
 
     auto mqttConfig = std::make_shared<MqttDriver::Config>();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -162,9 +162,6 @@ extern "C" void app_main() {
     // Reboots if update is successful
     handleHttpUpdate(fs, wifi);
 
-    // Enable power saving for WiFi if we don't need to do HTTP update
-    wifi->setPowerSaveMode(deviceConfig->sleepWhenIdle.get());
-
     auto mqttConfig = std::make_shared<MqttDriver::Config>();
     // TODO This should just be a "load()" call
     ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
@@ -179,6 +176,9 @@ extern "C" void app_main() {
     auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c, wifi, mdns, rtc, mqtt);
 
     new farmhub::devices::Device(deviceConfig, deviceDefinition, batteryManager, kernel);
+
+    // Enable power saving for WiFi only when we are done initializing
+    wifi->setPowerSaveMode(deviceConfig->sleepWhenIdle.get());
 
 #ifdef CONFIG_HEAP_TASK_TRACKING
     Task::loop("task-heaps", 4096, [](Task& task) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -110,7 +110,7 @@ extern "C" void app_main() {
 
     // TODO Move battery check before initializing file system
     auto i2c = std::make_shared<I2CManager>();
-    auto battery = deviceDefinition->createBatteryDriver(i2c);
+    auto battery = TDeviceDefinition::createBatteryDriver(i2c);
     std::shared_ptr<BatteryManager> batteryManager;
     if (battery != nullptr) {
         // If the battery voltage is below threshold, we should not boot yet.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -140,7 +140,7 @@ extern "C" void app_main() {
     StateSource networkConnectingState = stateManager.createStateSource("network-connecting");
     StateSource networkReadyState = stateManager.createStateSource("network-ready");
     StateSource configPortalRunningState = stateManager.createStateSource("config-portal-running");
-    std::shared_ptr<WiFiDriver> wifi = std::make_shared<WiFiDriver>(
+    auto wifi = std::make_shared<WiFiDriver>(
         networkConnectingState,
         networkReadyState,
         configPortalRunningState,
@@ -156,6 +156,9 @@ extern "C" void app_main() {
         batteryManager = std::make_shared<BatteryManager>(battery, shutdownManager);
     }
 
+    StateSource mdnsReadyState = stateManager.createStateSource("mdns-ready");
+    auto mdns = std::make_shared<MdnsDriver>(wifi->getNetworkReady(), deviceConfig->getHostname(), "ugly-duckling", farmhubVersion, mdnsReadyState);
+
     // Reboots if update is successful
     handleHttpUpdate(fs, wifi);
 
@@ -166,7 +169,7 @@ extern "C" void app_main() {
     // TODO This should just be a "load()" call
     ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
 
-    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c, wifi);
+    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c, wifi, mdns);
 
     new farmhub::devices::Device(deviceConfig, deviceDefinition, batteryManager, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -111,7 +111,7 @@ extern "C" void app_main() {
     // TODO Move battery check before initializing file system
     auto i2c = std::make_shared<I2CManager>();
     auto battery = deviceDefinition->createBatteryDriver(i2c);
-    shared_ptr<BatteryManager> batteryManager;
+    std::shared_ptr<BatteryManager> batteryManager;
     if (battery != nullptr) {
         // If the battery voltage is below threshold, we should not boot yet.
         // This is to prevent the device from booting and immediately shutting down

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -100,6 +100,8 @@ extern "C" void app_main() {
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));
 #endif
 
+    auto i2c = std::make_shared<I2CManager>();
+
     auto fs = FileSystem::get();
 
     auto deviceConfig = std::make_shared<TDeviceConfiguration>();
@@ -115,7 +117,7 @@ extern "C" void app_main() {
     // TODO This should just be a "load()" call
     ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
 
-    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed);
+    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, i2c);
 
     new farmhub::devices::Device(deviceConfig, deviceDefinition, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -125,6 +125,14 @@ extern "C" void app_main() {
     auto logRecords = std::make_shared<Queue<LogRecord>>("logs", 32);
     ConsoleProvider::init(logRecords, deviceConfig->publishLogs.get());
 
+    LOGD("   ______                   _    _       _");
+    LOGD("  |  ____|                 | |  | |     | |");
+    LOGD("  | |__ __ _ _ __ _ __ ___ | |__| |_   _| |__");
+    LOGD("  |  __/ _` | '__| '_ ` _ \\|  __  | | | | '_ \\");
+    LOGD("  | | | (_| | |  | | | | | | |  | | |_| | |_) |");
+    LOGD("  |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s", farmhubVersion);
+    LOGD("  ");
+
     auto deviceDefinition = std::make_shared<TDeviceDefinition>(deviceConfig);
 
     auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -7,8 +7,8 @@
 #include <memory>
 #include <string>
 
-#include <esp_app_desc.h>
 #include <driver/gpio.h>
+#include <esp_app_desc.h>
 
 static const char* const farmhubVersion = esp_app_get_description()->version;
 
@@ -100,9 +100,10 @@ extern "C" void app_main() {
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));
 #endif
 
-    std::shared_ptr<TDeviceDefinition> deviceDefinition = std::make_shared<TDeviceDefinition>();
+    auto deviceDefinition = std::make_shared<TDeviceDefinition>();
+    auto kernel = std::make_shared<Kernel<TDeviceConfiguration>>(deviceDefinition->config, deviceDefinition->mqttConfig, deviceDefinition->statusLed);
 
-    new farmhub::devices::Device(deviceDefinition);
+    new farmhub::devices::Device(deviceDefinition, kernel);
 
 #ifdef CONFIG_HEAP_TASK_TRACKING
     Task::loop("task-heaps", 4096, [](Task& task) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <string>
 
 #include <esp_app_desc.h>
@@ -99,7 +100,9 @@ extern "C" void app_main() {
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));
 #endif
 
-    new farmhub::devices::Device();
+    std::shared_ptr<TDeviceDefinition> deviceDefinition = std::make_shared<TDeviceDefinition>();
+
+    new farmhub::devices::Device(deviceDefinition);
 
 #ifdef CONFIG_HEAP_TASK_TRACKING
     Task::loop("task-heaps", 4096, [](Task& task) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -133,6 +133,17 @@ extern "C" void app_main() {
     LOGD("  |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s", farmhubVersion);
     LOGD("  ");
 
+    StateManager stateManager;
+    StateSource networkConnectingState = stateManager.createStateSource("network-connecting");
+    StateSource networkReadyState = stateManager.createStateSource("network-ready");
+    StateSource configPortalRunningState = stateManager.createStateSource("config-portal-running");
+    std::shared_ptr<WiFiDriver> wifi = std::make_shared<WiFiDriver>(
+        networkConnectingState,
+        networkReadyState,
+        configPortalRunningState,
+        deviceConfig->getHostname(),
+        deviceConfig->sleepWhenIdle.get());
+
     auto deviceDefinition = std::make_shared<TDeviceDefinition>(deviceConfig);
 
     auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);
@@ -149,7 +160,7 @@ extern "C" void app_main() {
     // TODO This should just be a "load()" call
     ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
 
-    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c);
+    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c, wifi);
 
     new farmhub::devices::Device(deviceConfig, deviceDefinition, batteryManager, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -100,8 +100,14 @@ extern "C" void app_main() {
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));
 #endif
 
+    auto fs = FileSystem::get();
+
+    auto mqttConfig = std::make_shared<MqttDriver::Config>();
+    // TODO This should just be a "load()" call
+    ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
+
     auto deviceDefinition = std::make_shared<TDeviceDefinition>();
-    auto kernel = std::make_shared<Kernel>(deviceDefinition->config, deviceDefinition->mqttConfig, deviceDefinition->statusLed);
+    auto kernel = std::make_shared<Kernel>(deviceDefinition->config, mqttConfig, deviceDefinition->statusLed);
 
     new farmhub::devices::Device(deviceDefinition, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -169,11 +169,14 @@ extern "C" void app_main() {
     // TODO This should just be a "load()" call
     ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
 
+    auto mqttReadyState = stateManager.createStateSource("mqtt-ready");
+    auto mqtt = std::make_shared<MqttDriver>(wifi->getNetworkReady(), mdns, mqttConfig, deviceConfig->instance.get(), deviceConfig->sleepWhenIdle.get(), mqttReadyState);
+
     // Init real time clock
     auto rtcInSyncState = stateManager.createStateSource("rtc-in-sync");
     auto rtc = std::make_shared<RtcDriver>(wifi->getNetworkReady(), mdns, deviceConfig->ntp.get(), rtcInSyncState);
 
-    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c, wifi, mdns, rtc);
+    auto kernel = std::make_shared<Kernel>(deviceConfig, mqttConfig, statusLed, shutdownManager, i2c, wifi, mdns, rtc, mqtt);
 
     new farmhub::devices::Device(deviceConfig, deviceDefinition, batteryManager, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -12,8 +12,9 @@
 
 static const char* const farmhubVersion = esp_app_get_description()->version;
 
-#include <kernel/Log.hpp>
 #include <kernel/BatteryManager.hpp>
+#include <kernel/Console.hpp>
+#include <kernel/Log.hpp>
 
 #ifdef CONFIG_HEAP_TRACING
 #include <esp_heap_trace.h>
@@ -120,6 +121,10 @@ extern "C" void app_main() {
     auto deviceConfig = std::make_shared<TDeviceConfiguration>();
     // TODO This should just be a "load()" call
     ConfigurationFile<TDeviceConfiguration> deviceConfigFile(fs, "/device-config.json", deviceConfig);
+
+    auto logRecords = std::make_shared<Queue<LogRecord>>("logs", 32);
+    ConsoleProvider::init(logRecords, deviceConfig->publishLogs.get());
+
     auto deviceDefinition = std::make_shared<TDeviceDefinition>(deviceConfig);
 
     auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -100,14 +100,17 @@ extern "C" void app_main() {
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));
 #endif
 
-    auto fs = FileSystem::get();
+    auto deviceDefinition = std::make_shared<TDeviceDefinition>();
+    auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);
 
+    // TODO Handle HTTP update here
+
+    auto fs = FileSystem::get();
     auto mqttConfig = std::make_shared<MqttDriver::Config>();
     // TODO This should just be a "load()" call
     ConfigurationFile<MqttDriver::Config> mqttConfigFile(fs, "/mqtt-config.json", mqttConfig);
 
-    auto deviceDefinition = std::make_shared<TDeviceDefinition>();
-    auto kernel = std::make_shared<Kernel>(deviceDefinition->config, mqttConfig, deviceDefinition->statusLed);
+    auto kernel = std::make_shared<Kernel>(deviceDefinition->config, mqttConfig, statusLed);
 
     new farmhub::devices::Device(deviceDefinition, kernel);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -144,8 +144,7 @@ extern "C" void app_main() {
         networkConnectingState,
         networkReadyState,
         configPortalRunningState,
-        deviceConfig->getHostname(),
-        deviceConfig->sleepWhenIdle.get());
+        deviceConfig->getHostname());
 
     auto deviceDefinition = std::make_shared<TDeviceDefinition>(deviceConfig);
 
@@ -153,6 +152,9 @@ extern "C" void app_main() {
 
     // Reboots if update is successful
     handleHttpUpdate(fs, wifi);
+
+    // Enable power saving for WiFi if we don't need to do HTTP update
+    wifi->setPowerSaveMode(deviceConfig->sleepWhenIdle.get());
 
     auto shutdownManager = std::make_shared<ShutdownManager>();
     std::shared_ptr<BatteryManager> batteryManager;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -150,17 +150,17 @@ extern "C" void app_main() {
 
     auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);
 
-    // Reboots if update is successful
-    handleHttpUpdate(fs, wifi);
-
-    // Enable power saving for WiFi if we don't need to do HTTP update
-    wifi->setPowerSaveMode(deviceConfig->sleepWhenIdle.get());
-
     auto shutdownManager = std::make_shared<ShutdownManager>();
     std::shared_ptr<BatteryManager> batteryManager;
     if (battery != nullptr) {
         batteryManager = std::make_shared<BatteryManager>(battery, shutdownManager);
     }
+
+    // Reboots if update is successful
+    handleHttpUpdate(fs, wifi);
+
+    // Enable power saving for WiFi if we don't need to do HTTP update
+    wifi->setPowerSaveMode(deviceConfig->sleepWhenIdle.get());
 
     auto mqttConfig = std::make_shared<MqttDriver::Config>();
     // TODO This should just be a "load()" call

--- a/main/peripherals/Peripheral.hpp
+++ b/main/peripherals/Peripheral.hpp
@@ -72,7 +72,7 @@ private:
     const size_t telemetrySize;
 };
 
-template <typename TConfig>
+template <std::derived_from<ConfigurationSection> TConfig>
 class Peripheral
     : public PeripheralBase {
 public:

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -158,9 +158,9 @@ public:
         }
     }
 
-    void configure(const ChickenDoorConfig& config) {
-        openLevel = config.openLevel.get();
-        closeLevel = config.closeLevel.get();
+    void configure(const std::shared_ptr<ChickenDoorConfig> config) {
+        openLevel = config->openLevel.get();
+        closeLevel = config->closeLevel.get();
         LOGI("Configured chicken door %s to close at %.2f lux, and open at %.2f lux",
             name.c_str(), closeLevel, openLevel);
     }
@@ -357,24 +357,24 @@ public:
         uint8_t lightSensorAddress,
         SwitchManager& switches,
         PwmMotorDriver& motor,
-        const ChickenDoorDeviceConfig& config)
+        const std::shared_ptr<ChickenDoorDeviceConfig> config)
         : Peripheral<ChickenDoorConfig>(name, mqttRoot)
         , lightSensor(
               name + ":light",
               mqttRoot,
               i2c,
-              config.lightSensor.get().parse(lightSensorAddress),
-              config.lightSensor.get().measurementFrequency.get(),
-              config.lightSensor.get().latencyInterval.get())
+              config->lightSensor.get()->parse(lightSensorAddress),
+              config->lightSensor.get()->measurementFrequency.get(),
+              config->lightSensor.get()->latencyInterval.get())
         , doorComponent(
               name,
               mqttRoot,
               switches,
               motor,
               lightSensor,
-              config.openPin.get(),
-              config.closedPin.get(),
-              config.movementTimeout.get(),
+              config->openPin.get(),
+              config->closedPin.get(),
+              config->movementTimeout.get(),
               [this]() {
                   publishTelemetry();
               }) {
@@ -385,7 +385,7 @@ public:
         doorComponent.populateTelemetry(telemetryJson);
     }
 
-    void configure(const ChickenDoorConfig& config) override {
+    void configure(const std::shared_ptr<ChickenDoorConfig> config) override {
         doorComponent.configure(config);
     }
 
@@ -422,9 +422,9 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<ChickenDoorConfig>> createPeripheral(const std::string& name, const ChickenDoorDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        PwmMotorDriver& motor = findMotor(deviceConfig.motor.get());
-        auto lightSensorType = deviceConfig.lightSensor.get().type.get();
+    unique_ptr<Peripheral<ChickenDoorConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ChickenDoorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        PwmMotorDriver& motor = findMotor(deviceConfig->motor.get());
+        auto lightSensorType = deviceConfig->lightSensor.get()->type.get();
         try {
             if (lightSensorType == "bh1750") {
                 return std::make_unique<ChickenDoor<Bh1750Component>>(name, mqttRoot, services.i2c, 0x23, services.switches, motor, deviceConfig);

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <concepts>
 #include <limits>
 #include <list>
 #include <variant>
@@ -80,7 +81,7 @@ public:
     Property<double> closeLevel { this, "closeLevel", 10 };
 };
 
-template <typename TLightSensorComponent>
+template <std::derived_from<LightSensorComponent> TLightSensorComponent>
 class ChickenDoorComponent
     : public Component,
       public TelemetryProvider {
@@ -198,9 +199,7 @@ private:
                     static_cast<int>(currentState), lightSensor.getCurrentLevel());
                 watchdog.cancel();
                 motor.stop();
-                mqttRoot->publish("events/state", [=](JsonObject& json) {
-                    json["state"] = currentState;
-                }, Retention::NoRetain, QoS::AtLeastOnce);
+                mqttRoot->publish("events/state", [=](JsonObject& json) { json["state"] = currentState; }, Retention::NoRetain, QoS::AtLeastOnce);
             }
         }
 
@@ -346,7 +345,7 @@ private:
     std::optional<PowerManagementLockGuard> sleepLock;
 };
 
-template <typename TLightSensorComponent>
+template <std::derived_from<LightSensorComponent> TLightSensorComponent>
 class ChickenDoor
     : public Peripheral<ChickenDoorConfig> {
 public:

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -89,7 +89,7 @@ public:
     ChickenDoorComponent(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        SwitchManager& switches,
+        std::shared_ptr<SwitchManager> switches,
         PwmMotorDriver& motor,
         TLightSensorComponent& lightSensor,
         InternalPinPtr openPin,
@@ -99,13 +99,13 @@ public:
         : Component(name, mqttRoot)
         , motor(motor)
         , lightSensor(lightSensor)
-        , openSwitch(switches.registerHandler(
+        , openSwitch(switches->registerHandler(
               name + ":open",
               openPin,
               SwitchMode::PullUp,
               [this](const Switch&) { updateState(); },
               [this](const Switch&, milliseconds) { updateState(); }))
-        , closedSwitch(switches.registerHandler(
+        , closedSwitch(switches->registerHandler(
               name + ":closed",
               closedPin,
               SwitchMode::PullUp,
@@ -351,10 +351,10 @@ class ChickenDoor
 public:
     ChickenDoor(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<I2CManager> i2c,
         uint8_t lightSensorAddress,
-        SwitchManager& switches,
+        std::shared_ptr<SwitchManager> switches,
         PwmMotorDriver& motor,
         const std::shared_ptr<ChickenDoorDeviceConfig> config)
         : Peripheral<ChickenDoorConfig>(name, mqttRoot)
@@ -398,7 +398,7 @@ public:
     NoLightSensorComponent(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         I2CConfig config,
         seconds measurementFrequency,
         seconds latencyInterval)
@@ -421,7 +421,7 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<ChickenDoorConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ChickenDoorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<ChickenDoorConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ChickenDoorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         PwmMotorDriver& motor = findMotor(deviceConfig->motor.get());
         auto lightSensorType = deviceConfig->lightSensor.get()->type.get();
         try {

--- a/main/peripherals/chicken_door/ChickenDoor.hpp
+++ b/main/peripherals/chicken_door/ChickenDoor.hpp
@@ -88,7 +88,7 @@ class ChickenDoorComponent
 public:
     ChickenDoorComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<SwitchManager> switches,
         PwmMotorDriver& motor,
         TLightSensorComponent& lightSensor,
@@ -397,7 +397,7 @@ class NoLightSensorComponent : public LightSensorComponent {
 public:
     NoLightSensorComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         I2CConfig config,
         seconds measurementFrequency,
@@ -421,7 +421,7 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<ChickenDoorConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ChickenDoorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<ChickenDoorConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ChickenDoorDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         PwmMotorDriver& motor = findMotor(deviceConfig->motor.get());
         auto lightSensorType = deviceConfig->lightSensor.get()->type.get();
         try {

--- a/main/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/main/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -12,8 +12,7 @@
 using namespace farmhub::kernel;
 using namespace farmhub::kernel::mqtt;
 using namespace farmhub::peripherals;
-using std::make_unique;
-using std::unique_ptr;
+
 namespace farmhub::peripherals::environment {
 
 /**
@@ -27,7 +26,7 @@ class Ds18B20SoilSensorComponent
 public:
     Ds18B20SoilSensorComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         InternalPinPtr pin)
         : Component(name, mqttRoot)
         , pin(pin) {
@@ -68,7 +67,7 @@ private:
 class Ds18B20SoilSensor
     : public Peripheral<EmptyConfiguration> {
 public:
-    Ds18B20SoilSensor(const std::string& name, shared_ptr<MqttRoot> mqttRoot, InternalPinPtr pin)
+    Ds18B20SoilSensor(const std::string& name, std::shared_ptr<MqttRoot> mqttRoot, InternalPinPtr pin)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , sensor(name, mqttRoot, pin) {
     }
@@ -88,8 +87,8 @@ public:
         : PeripheralFactory<SinglePinDeviceConfig, EmptyConfiguration>("environment:ds18b20", "environment") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SinglePinDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
-        return make_unique<Ds18B20SoilSensor>(name, mqttRoot, deviceConfig->pin.get());
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SinglePinDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+        return std::make_unique<Ds18B20SoilSensor>(name, mqttRoot, deviceConfig->pin.get());
     }
 };
 

--- a/main/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/main/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -88,7 +88,7 @@ public:
         : PeripheralFactory<SinglePinDeviceConfig, EmptyConfiguration>("environment:ds18b20", "environment") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SinglePinDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SinglePinDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return make_unique<Ds18B20SoilSensor>(name, mqttRoot, deviceConfig->pin.get());
     }
 };

--- a/main/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/main/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -88,8 +88,8 @@ public:
         : PeripheralFactory<SinglePinDeviceConfig, EmptyConfiguration>("environment:ds18b20", "environment") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const SinglePinDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        return make_unique<Ds18B20SoilSensor>(name, mqttRoot, deviceConfig.pin.get());
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SinglePinDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        return make_unique<Ds18B20SoilSensor>(name, mqttRoot, deviceConfig->pin.get());
     }
 };
 

--- a/main/peripherals/environment/Environment.hpp
+++ b/main/peripherals/environment/Environment.hpp
@@ -25,7 +25,7 @@ public:
         const std::string& name,
         const std::string& sensorType,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         I2CConfig config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , component(name, sensorType, mqttRoot, i2c, config) {
@@ -49,7 +49,7 @@ public:
         , defaultAddress(defaultAddress) {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<I2CDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<I2CDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         auto i2cConfig = deviceConfig->parse(defaultAddress);
         LOGI("Creating %s sensor %s with %s",
             sensorType.c_str(), name.c_str(), i2cConfig.toString().c_str());

--- a/main/peripherals/environment/Environment.hpp
+++ b/main/peripherals/environment/Environment.hpp
@@ -48,8 +48,8 @@ public:
         , defaultAddress(defaultAddress) {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const I2CDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        auto i2cConfig = deviceConfig.parse(defaultAddress);
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<I2CDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        auto i2cConfig = deviceConfig->parse(defaultAddress);
         LOGI("Creating %s sensor %s with %s",
             sensorType.c_str(), name.c_str(), i2cConfig.toString().c_str());
         return make_unique<Environment<TComponent>>(name, sensorType, mqttRoot, services.i2c, i2cConfig);

--- a/main/peripherals/environment/Environment.hpp
+++ b/main/peripherals/environment/Environment.hpp
@@ -12,8 +12,6 @@
 using namespace farmhub::kernel;
 using namespace farmhub::kernel::mqtt;
 using namespace farmhub::peripherals;
-using std::make_unique;
-using std::unique_ptr;
 
 namespace farmhub::peripherals::environment {
 
@@ -24,7 +22,7 @@ public:
     Environment(
         const std::string& name,
         const std::string& sensorType,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         I2CConfig config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
@@ -49,11 +47,11 @@ public:
         , defaultAddress(defaultAddress) {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<I2CDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<I2CDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         auto i2cConfig = deviceConfig->parse(defaultAddress);
         LOGI("Creating %s sensor %s with %s",
             sensorType.c_str(), name.c_str(), i2cConfig.toString().c_str());
-        return make_unique<Environment<TComponent>>(name, sensorType, mqttRoot, services.i2c, i2cConfig);
+        return std::make_unique<Environment<TComponent>>(name, sensorType, mqttRoot, services.i2c, i2cConfig);
     }
 
 private:

--- a/main/peripherals/environment/Environment.hpp
+++ b/main/peripherals/environment/Environment.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <memory>
 
 #include <kernel/Configuration.hpp>
@@ -16,7 +17,7 @@ using std::unique_ptr;
 
 namespace farmhub::peripherals::environment {
 
-template <typename TComponent>
+template <std::derived_from<Component> TComponent>
 class Environment
     : public Peripheral<EmptyConfiguration> {
 public:
@@ -38,7 +39,7 @@ private:
     TComponent component;
 };
 
-template <typename TComponent>
+template <std::derived_from<Component> TComponent>
 class I2CEnvironmentFactory
     : public PeripheralFactory<I2CDeviceConfig, EmptyConfiguration> {
 public:

--- a/main/peripherals/environment/Sht2xComponent.hpp
+++ b/main/peripherals/environment/Sht2xComponent.hpp
@@ -28,7 +28,7 @@ public:
         const std::string& sensorType,
         shared_ptr<MqttRoot> mqttRoot,
         I2CManager& i2c,
-        I2CConfig config)
+        const I2CConfig& config)
         : Component(name, mqttRoot)
         , bus(i2c.getBusFor(config)) {
 

--- a/main/peripherals/environment/Sht2xComponent.hpp
+++ b/main/peripherals/environment/Sht2xComponent.hpp
@@ -27,10 +27,10 @@ public:
         const std::string& name,
         const std::string& sensorType,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         const I2CConfig& config)
         : Component(name, mqttRoot)
-        , bus(i2c.getBusFor(config)) {
+        , bus(i2c->getBusFor(config)) {
 
         // TODO Add commands to soft/hard reset the sensor
         // TODO Add configuration for fast / slow measurement

--- a/main/peripherals/environment/Sht2xComponent.hpp
+++ b/main/peripherals/environment/Sht2xComponent.hpp
@@ -26,7 +26,7 @@ public:
     Sht2xComponent(
         const std::string& name,
         const std::string& sensorType,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         const I2CConfig& config)
         : Component(name, mqttRoot)
@@ -70,7 +70,7 @@ private:
         }
     }
 
-    shared_ptr<I2CBus> bus;
+    std::shared_ptr<I2CBus> bus;
     i2c_dev_t sensor {};
 };
 

--- a/main/peripherals/environment/Sht3xComponent.hpp
+++ b/main/peripherals/environment/Sht3xComponent.hpp
@@ -23,7 +23,7 @@ public:
     Sht3xComponent(
         const std::string& name,
         const std::string& sensorType,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         I2CConfig config)
         : Component(name, mqttRoot)
@@ -55,7 +55,7 @@ public:
     }
 
 private:
-    shared_ptr<I2CBus> bus;
+    std::shared_ptr<I2CBus> bus;
     sht3x_t sensor {};
 };
 

--- a/main/peripherals/environment/Sht3xComponent.hpp
+++ b/main/peripherals/environment/Sht3xComponent.hpp
@@ -24,10 +24,10 @@ public:
         const std::string& name,
         const std::string& sensorType,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         I2CConfig config)
         : Component(name, mqttRoot)
-        , bus(i2c.getBusFor(config)) {
+        , bus(i2c->getBusFor(config)) {
 
         // TODO Add commands to soft/hard reset the sensor
         // TODO Add configuration for fast / slow measurement

--- a/main/peripherals/environment/SoilMoistureSensor.hpp
+++ b/main/peripherals/environment/SoilMoistureSensor.hpp
@@ -28,11 +28,11 @@ public:
     SoilMoistureSensorComponent(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        const SoilMoistureSensorDeviceConfig& config)
+        const std::shared_ptr<SoilMoistureSensorDeviceConfig> config)
         : Component(name, mqttRoot)
-        , airValue(config.air.get())
-        , waterValue(config.water.get())
-        , pin(config.pin.get()) {
+        , airValue(config->air.get())
+        , waterValue(config->water.get())
+        , pin(config->pin.get()) {
 
         LOGI("Initializing soil moisture sensor on pin %s; air value: %d; water value: %d",
             pin.getName().c_str(), airValue, waterValue);
@@ -64,7 +64,7 @@ private:
 class SoilMoistureSensor
     : public Peripheral<EmptyConfiguration> {
 public:
-    SoilMoistureSensor(const std::string& name, shared_ptr<MqttRoot> mqttRoot, const SoilMoistureSensorDeviceConfig& config)
+    SoilMoistureSensor(const std::string& name, shared_ptr<MqttRoot> mqttRoot, const std::shared_ptr<SoilMoistureSensorDeviceConfig> config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , sensor(name, mqttRoot, config) {
     }
@@ -84,7 +84,7 @@ public:
         : PeripheralFactory<SoilMoistureSensorDeviceConfig, EmptyConfiguration>("environment:soil-moisture", "environment") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const SoilMoistureSensorDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SoilMoistureSensorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
         return std::make_unique<SoilMoistureSensor>(name, mqttRoot, deviceConfig);
     }
 };

--- a/main/peripherals/environment/SoilMoistureSensor.hpp
+++ b/main/peripherals/environment/SoilMoistureSensor.hpp
@@ -84,7 +84,7 @@ public:
         : PeripheralFactory<SoilMoistureSensorDeviceConfig, EmptyConfiguration>("environment:soil-moisture", "environment") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SoilMoistureSensorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SoilMoistureSensorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return std::make_unique<SoilMoistureSensor>(name, mqttRoot, deviceConfig);
     }
 };

--- a/main/peripherals/environment/SoilMoistureSensor.hpp
+++ b/main/peripherals/environment/SoilMoistureSensor.hpp
@@ -27,7 +27,7 @@ class SoilMoistureSensorComponent
 public:
     SoilMoistureSensorComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         const std::shared_ptr<SoilMoistureSensorDeviceConfig> config)
         : Component(name, mqttRoot)
         , airValue(config->air.get())
@@ -64,7 +64,7 @@ private:
 class SoilMoistureSensor
     : public Peripheral<EmptyConfiguration> {
 public:
-    SoilMoistureSensor(const std::string& name, shared_ptr<MqttRoot> mqttRoot, const std::shared_ptr<SoilMoistureSensorDeviceConfig> config)
+    SoilMoistureSensor(const std::string& name, std::shared_ptr<MqttRoot> mqttRoot, const std::shared_ptr<SoilMoistureSensorDeviceConfig> config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , sensor(name, mqttRoot, config) {
     }
@@ -84,7 +84,7 @@ public:
         : PeripheralFactory<SoilMoistureSensorDeviceConfig, EmptyConfiguration>("environment:soil-moisture", "environment") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SoilMoistureSensorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<SoilMoistureSensorDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return std::make_unique<SoilMoistureSensor>(name, mqttRoot, deviceConfig);
     }
 };

--- a/main/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/main/peripherals/fence/ElectricFenceMonitor.hpp
@@ -45,7 +45,7 @@ public:
     ElectricFenceMonitorComponent(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PulseCounterManager& pulseCounterManager,
+        std::shared_ptr<PulseCounterManager> pulseCounterManager,
         const std::shared_ptr<ElectricFenceMonitorDeviceConfig> config)
         : Component(name, mqttRoot) {
 
@@ -58,7 +58,7 @@ public:
         LOGI("Initializing electric fence with pins %s", pinsDescription.c_str());
 
         for (auto& pinConfig : config->pins.get()) {
-            auto unit = pulseCounterManager.create(pinConfig.pin);
+            auto unit = pulseCounterManager->create(pinConfig.pin);
             pins.emplace_back(pinConfig.voltage, unit);
         }
 
@@ -102,7 +102,7 @@ public:
     ElectricFenceMonitor(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PulseCounterManager& pulseCounterManager,
+        std::shared_ptr<PulseCounterManager> pulseCounterManager,
         const std::shared_ptr<ElectricFenceMonitorDeviceConfig> config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , monitor(name, mqttRoot, pulseCounterManager, config) {
@@ -123,7 +123,7 @@ public:
         : PeripheralFactory<ElectricFenceMonitorDeviceConfig, EmptyConfiguration>("electric-fence") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<ElectricFenceMonitorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<ElectricFenceMonitorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return std::make_unique<ElectricFenceMonitor>(name, mqttRoot, services.pulseCounterManager, deviceConfig);
     }
 };

--- a/main/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/main/peripherals/fence/ElectricFenceMonitor.hpp
@@ -46,23 +46,23 @@ public:
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
         PulseCounterManager& pulseCounterManager,
-        const ElectricFenceMonitorDeviceConfig& config)
+        const std::shared_ptr<ElectricFenceMonitorDeviceConfig> config)
         : Component(name, mqttRoot) {
 
         std::string pinsDescription;
-        for (auto& pinConfig : config.pins.get()) {
+        for (auto& pinConfig : config->pins.get()) {
             if (pinsDescription.length() > 0)
                 pinsDescription += ", ";
             pinsDescription += pinConfig.pin->getName() + "=" + std::to_string(pinConfig.voltage) + "V";
         }
         LOGI("Initializing electric fence with pins %s", pinsDescription.c_str());
 
-        for (auto& pinConfig : config.pins.get()) {
+        for (auto& pinConfig : config->pins.get()) {
             auto unit = pulseCounterManager.create(pinConfig.pin);
             pins.emplace_back(pinConfig.voltage, unit);
         }
 
-        auto measurementFrequency = config.measurementFrequency.get();
+        auto measurementFrequency = config->measurementFrequency.get();
         Task::loop(name, 3172, [this, measurementFrequency](Task& task) {
             uint16_t lastVoltage = 0;
             for (auto& pin : pins) {
@@ -103,7 +103,7 @@ public:
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
         PulseCounterManager& pulseCounterManager,
-        const ElectricFenceMonitorDeviceConfig& config)
+        const std::shared_ptr<ElectricFenceMonitorDeviceConfig> config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , monitor(name, mqttRoot, pulseCounterManager, config) {
     }
@@ -123,7 +123,7 @@ public:
         : PeripheralFactory<ElectricFenceMonitorDeviceConfig, EmptyConfiguration>("electric-fence") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const ElectricFenceMonitorDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<ElectricFenceMonitorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
         return std::make_unique<ElectricFenceMonitor>(name, mqttRoot, services.pulseCounterManager, deviceConfig);
     }
 };

--- a/main/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/main/peripherals/fence/ElectricFenceMonitor.hpp
@@ -44,7 +44,7 @@ class ElectricFenceMonitorComponent
 public:
     ElectricFenceMonitorComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<PulseCounterManager> pulseCounterManager,
         const std::shared_ptr<ElectricFenceMonitorDeviceConfig> config)
         : Component(name, mqttRoot) {
@@ -90,7 +90,7 @@ private:
 
     struct FencePin {
         uint16_t voltage;
-        shared_ptr<PulseCounter> counter;
+        std::shared_ptr<PulseCounter> counter;
     };
 
     std::list<FencePin> pins;
@@ -101,7 +101,7 @@ class ElectricFenceMonitor
 public:
     ElectricFenceMonitor(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<PulseCounterManager> pulseCounterManager,
         const std::shared_ptr<ElectricFenceMonitorDeviceConfig> config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
@@ -123,7 +123,7 @@ public:
         : PeripheralFactory<ElectricFenceMonitorDeviceConfig, EmptyConfiguration>("electric-fence") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<ElectricFenceMonitorDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<ElectricFenceMonitorDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return std::make_unique<ElectricFenceMonitor>(name, mqttRoot, services.pulseCounterManager, deviceConfig);
     }
 };

--- a/main/peripherals/flow_control/FlowControl.hpp
+++ b/main/peripherals/flow_control/FlowControl.hpp
@@ -42,8 +42,8 @@ public:
         , flowMeter(name, mqttRoot, pulseCounterManager, pin, qFactor, measurementFrequency) {
     }
 
-    void configure(const FlowControlConfig& config) override {
-        valve.setSchedules(config.schedule.get());
+    void configure(const std::shared_ptr<FlowControlConfig> config) override {
+        valve.setSchedules(config->schedule.get());
     }
 
     void populateTelemetry(JsonObject& telemetryJson) override {
@@ -83,10 +83,10 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<FlowControlConfig>> createPeripheral(const std::string& name, const FlowControlDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        auto strategy = deviceConfig.valve.get().createValveControlStrategy(this);
+    unique_ptr<Peripheral<FlowControlConfig>> createPeripheral(const std::string& name, const std::shared_ptr<FlowControlDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        auto strategy = deviceConfig->valve.get()->createValveControlStrategy(this);
 
-        auto flowMeterConfig = deviceConfig.flowMeter.get();
+        auto flowMeterConfig = deviceConfig->flowMeter.get();
         return make_unique<FlowControl>(
             name,
             mqttRoot,
@@ -94,9 +94,9 @@ public:
 
             *strategy,
 
-            flowMeterConfig.pin.get(),
-            flowMeterConfig.qFactor.get(),
-            flowMeterConfig.measurementFrequency.get());
+            flowMeterConfig->pin.get(),
+            flowMeterConfig->qFactor.get(),
+            flowMeterConfig->measurementFrequency.get());
     }
 
 private:

--- a/main/peripherals/flow_control/FlowControl.hpp
+++ b/main/peripherals/flow_control/FlowControl.hpp
@@ -16,8 +16,6 @@ using namespace farmhub::kernel::mqtt;
 using namespace farmhub::peripherals;
 using namespace farmhub::peripherals::flow_meter;
 using namespace farmhub::peripherals::valve;
-using std::make_unique;
-using std::unique_ptr;
 
 namespace farmhub::peripherals::flow_control {
 
@@ -29,7 +27,7 @@ class FlowControl : public Peripheral<FlowControlConfig> {
 public:
     FlowControl(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<PulseCounterManager> pulseCounterManager,
         ValveControlStrategy& strategy,
         InternalPinPtr pin,
@@ -83,11 +81,11 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<FlowControlConfig>> createPeripheral(const std::string& name, const std::shared_ptr<FlowControlDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<FlowControlConfig>> createPeripheral(const std::string& name, const std::shared_ptr<FlowControlDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         auto strategy = deviceConfig->valve.get()->createValveControlStrategy(this);
 
         auto flowMeterConfig = deviceConfig->flowMeter.get();
-        return make_unique<FlowControl>(
+        return std::make_unique<FlowControl>(
             name,
             mqttRoot,
             services.pulseCounterManager,

--- a/main/peripherals/flow_control/FlowControl.hpp
+++ b/main/peripherals/flow_control/FlowControl.hpp
@@ -30,7 +30,7 @@ public:
     FlowControl(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PulseCounterManager& pulseCounterManager,
+        std::shared_ptr<PulseCounterManager> pulseCounterManager,
         ValveControlStrategy& strategy,
         InternalPinPtr pin,
         double qFactor,
@@ -83,7 +83,7 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<FlowControlConfig>> createPeripheral(const std::string& name, const std::shared_ptr<FlowControlDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<FlowControlConfig>> createPeripheral(const std::string& name, const std::shared_ptr<FlowControlDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         auto strategy = deviceConfig->valve.get()->createValveControlStrategy(this);
 
         auto flowMeterConfig = deviceConfig->flowMeter.get();

--- a/main/peripherals/flow_meter/FlowMeter.hpp
+++ b/main/peripherals/flow_meter/FlowMeter.hpp
@@ -44,8 +44,8 @@ public:
         : PeripheralFactory<FlowMeterDeviceConfig, EmptyConfiguration>("flow-meter") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const FlowMeterDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        return make_unique<FlowMeter>(name, mqttRoot, services.pulseCounterManager, deviceConfig.pin.get(), deviceConfig.qFactor.get(), deviceConfig.measurementFrequency.get());
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<FlowMeterDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        return make_unique<FlowMeter>(name, mqttRoot, services.pulseCounterManager, deviceConfig->pin.get(), deviceConfig->qFactor.get(), deviceConfig->measurementFrequency.get());
     }
 };
 

--- a/main/peripherals/flow_meter/FlowMeter.hpp
+++ b/main/peripherals/flow_meter/FlowMeter.hpp
@@ -21,7 +21,7 @@ public:
     FlowMeter(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PulseCounterManager& pulseCounterManager,
+        std::shared_ptr<PulseCounterManager> pulseCounterManager,
         InternalPinPtr pin,
         double qFactor,
         milliseconds measurementFrequency)
@@ -44,7 +44,7 @@ public:
         : PeripheralFactory<FlowMeterDeviceConfig, EmptyConfiguration>("flow-meter") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<FlowMeterDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<FlowMeterDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return make_unique<FlowMeter>(name, mqttRoot, services.pulseCounterManager, deviceConfig->pin.get(), deviceConfig->qFactor.get(), deviceConfig->measurementFrequency.get());
     }
 };

--- a/main/peripherals/flow_meter/FlowMeter.hpp
+++ b/main/peripherals/flow_meter/FlowMeter.hpp
@@ -11,8 +11,7 @@
 using namespace farmhub::kernel;
 using namespace farmhub::kernel::mqtt;
 using namespace farmhub::peripherals;
-using std::make_unique;
-using std::unique_ptr;
+
 namespace farmhub::peripherals::flow_meter {
 
 class FlowMeter
@@ -20,7 +19,7 @@ class FlowMeter
 public:
     FlowMeter(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<PulseCounterManager> pulseCounterManager,
         InternalPinPtr pin,
         double qFactor,
@@ -44,8 +43,8 @@ public:
         : PeripheralFactory<FlowMeterDeviceConfig, EmptyConfiguration>("flow-meter") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<FlowMeterDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
-        return make_unique<FlowMeter>(name, mqttRoot, services.pulseCounterManager, deviceConfig->pin.get(), deviceConfig->qFactor.get(), deviceConfig->measurementFrequency.get());
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<FlowMeterDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+        return std::make_unique<FlowMeter>(name, mqttRoot, services.pulseCounterManager, deviceConfig->pin.get(), deviceConfig->qFactor.get(), deviceConfig->measurementFrequency.get());
     }
 };
 

--- a/main/peripherals/flow_meter/FlowMeterComponent.hpp
+++ b/main/peripherals/flow_meter/FlowMeterComponent.hpp
@@ -22,7 +22,7 @@ class FlowMeterComponent
 public:
     FlowMeterComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<PulseCounterManager> pulseCounterManager,
         InternalPinPtr pin,
         double qFactor,
@@ -82,7 +82,7 @@ private:
         lastPublished = lastMeasurement;
     }
 
-    shared_ptr<PulseCounter> counter;
+    std::shared_ptr<PulseCounter> counter;
     const double qFactor;
 
     time_point<boot_clock> lastMeasurement;

--- a/main/peripherals/flow_meter/FlowMeterComponent.hpp
+++ b/main/peripherals/flow_meter/FlowMeterComponent.hpp
@@ -23,7 +23,7 @@ public:
     FlowMeterComponent(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        PulseCounterManager& pulseCounterManager,
+        std::shared_ptr<PulseCounterManager> pulseCounterManager,
         InternalPinPtr pin,
         double qFactor,
         milliseconds measurementFrequency)
@@ -33,7 +33,7 @@ public:
         LOGI("Initializing flow meter on pin %s with Q = %.2f",
             pin->getName().c_str(), qFactor);
 
-        counter = pulseCounterManager.create(pin);
+        counter = pulseCounterManager->create(pin);
 
         auto now = boot_clock::now();
         lastMeasurement = now;

--- a/main/peripherals/light_sensor/Bh1750.hpp
+++ b/main/peripherals/light_sensor/Bh1750.hpp
@@ -37,7 +37,7 @@ public:
     Bh1750Component(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         I2CConfig config,
         seconds measurementFrequency,
         seconds latencyInterval)
@@ -73,7 +73,7 @@ public:
     Bh1750(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         const I2CConfig& config,
         seconds measurementFrequency,
         seconds latencyInterval)
@@ -96,7 +96,7 @@ public:
         : PeripheralFactory<Bh1750DeviceConfig, EmptyConfiguration>("light-sensor:bh1750", "light-sensor") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Bh1750DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Bh1750DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         I2CConfig i2cConfig = deviceConfig->parse(0x23);
         return std::make_unique<Bh1750>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig->measurementFrequency.get(), deviceConfig->latencyInterval.get());
     }

--- a/main/peripherals/light_sensor/Bh1750.hpp
+++ b/main/peripherals/light_sensor/Bh1750.hpp
@@ -36,7 +36,7 @@ class Bh1750Component
 public:
     Bh1750Component(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         I2CConfig config,
         seconds measurementFrequency,
@@ -72,7 +72,7 @@ class Bh1750
 public:
     Bh1750(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         const I2CConfig& config,
         seconds measurementFrequency,
@@ -96,7 +96,7 @@ public:
         : PeripheralFactory<Bh1750DeviceConfig, EmptyConfiguration>("light-sensor:bh1750", "light-sensor") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Bh1750DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Bh1750DeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         I2CConfig i2cConfig = deviceConfig->parse(0x23);
         return std::make_unique<Bh1750>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig->measurementFrequency.get(), deviceConfig->latencyInterval.get());
     }

--- a/main/peripherals/light_sensor/Bh1750.hpp
+++ b/main/peripherals/light_sensor/Bh1750.hpp
@@ -96,9 +96,9 @@ public:
         : PeripheralFactory<Bh1750DeviceConfig, EmptyConfiguration>("light-sensor:bh1750", "light-sensor") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const Bh1750DeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        I2CConfig i2cConfig = deviceConfig.parse(0x23);
-        return std::make_unique<Bh1750>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig.measurementFrequency.get(), deviceConfig.latencyInterval.get());
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Bh1750DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        I2CConfig i2cConfig = deviceConfig->parse(0x23);
+        return std::make_unique<Bh1750>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig->measurementFrequency.get(), deviceConfig->latencyInterval.get());
     }
 };
 

--- a/main/peripherals/light_sensor/LightSensor.hpp
+++ b/main/peripherals/light_sensor/LightSensor.hpp
@@ -26,7 +26,7 @@ class LightSensorComponent
 public:
     LightSensorComponent(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         seconds measurementFrequency,
         seconds latencyInterval)
         : Component(name, mqttRoot)

--- a/main/peripherals/light_sensor/Tsl2591.hpp
+++ b/main/peripherals/light_sensor/Tsl2591.hpp
@@ -37,12 +37,12 @@ public:
     Tsl2591Component(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         I2CConfig config,
         seconds measurementFrequency,
         seconds latencyInterval)
         : LightSensorComponent(name, mqttRoot, measurementFrequency, latencyInterval)
-        , bus(i2c.getBusFor(config)) {
+        , bus(i2c->getBusFor(config)) {
 
         LOGI("Initializing TSL2591 light sensor with %s",
             config.toString().c_str());
@@ -83,7 +83,7 @@ public:
     Tsl2591(
         const std::string& name,
         shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<I2CManager> i2c,
         const I2CConfig& config,
         seconds measurementFrequency,
         seconds latencyInterval)
@@ -106,7 +106,7 @@ public:
         : PeripheralFactory<Tsl2591DeviceConfig, EmptyConfiguration>("light-sensor:tsl2591", "light-sensor") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Tsl2591DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Tsl2591DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         I2CConfig i2cConfig = deviceConfig->parse(TSL2591_ADDR);
         return std::make_unique<Tsl2591>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig->measurementFrequency.get(), deviceConfig->latencyInterval.get());
     }

--- a/main/peripherals/light_sensor/Tsl2591.hpp
+++ b/main/peripherals/light_sensor/Tsl2591.hpp
@@ -106,9 +106,9 @@ public:
         : PeripheralFactory<Tsl2591DeviceConfig, EmptyConfiguration>("light-sensor:tsl2591", "light-sensor") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const Tsl2591DeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        I2CConfig i2cConfig = deviceConfig.parse(TSL2591_ADDR);
-        return std::make_unique<Tsl2591>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig.measurementFrequency.get(), deviceConfig.latencyInterval.get());
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Tsl2591DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        I2CConfig i2cConfig = deviceConfig->parse(TSL2591_ADDR);
+        return std::make_unique<Tsl2591>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig->measurementFrequency.get(), deviceConfig->latencyInterval.get());
     }
 };
 

--- a/main/peripherals/light_sensor/Tsl2591.hpp
+++ b/main/peripherals/light_sensor/Tsl2591.hpp
@@ -36,7 +36,7 @@ class Tsl2591Component
 public:
     Tsl2591Component(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         I2CConfig config,
         seconds measurementFrequency,
@@ -72,7 +72,7 @@ protected:
     }
 
 private:
-    shared_ptr<I2CBus> bus;
+    std::shared_ptr<I2CBus> bus;
     tsl2591_t sensor {};
 };
 
@@ -82,7 +82,7 @@ class Tsl2591
 public:
     Tsl2591(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::shared_ptr<I2CManager> i2c,
         const I2CConfig& config,
         seconds measurementFrequency,
@@ -106,7 +106,7 @@ public:
         : PeripheralFactory<Tsl2591DeviceConfig, EmptyConfiguration>("light-sensor:tsl2591", "light-sensor") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Tsl2591DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Tsl2591DeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         I2CConfig i2cConfig = deviceConfig->parse(TSL2591_ADDR);
         return std::make_unique<Tsl2591>(name, mqttRoot, services.i2c, i2cConfig, deviceConfig->measurementFrequency.get(), deviceConfig->latencyInterval.get());
     }

--- a/main/peripherals/multiplexer/Xl9535.hpp
+++ b/main/peripherals/multiplexer/Xl9535.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <kernel/Pin.hpp>
 #include <kernel/Component.hpp>
 #include <kernel/Configuration.hpp>
+#include <kernel/Pin.hpp>
 
 namespace farmhub::peripherals::multiplexer {
 
@@ -16,11 +16,11 @@ class Xl9535Component
 public:
     Xl9535Component(
         const std::string& name,
-        shared_ptr<MqttRoot> mqttRoot,
-        I2CManager& i2c,
+        std::shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<I2CManager> i2c,
         I2CConfig config)
         : Component(name, mqttRoot)
-        , device(i2c.createDevice(name, config)) {
+        , device(i2c->createDevice(name, config)) {
         LOGI("Initializing XL9535 multiplexer with %s",
             config.toString().c_str());
     }
@@ -109,7 +109,7 @@ private:
 class Xl9535
     : public Peripheral<EmptyConfiguration> {
 public:
-    Xl9535(const std::string& name, shared_ptr<MqttRoot> mqttRoot, I2CManager& i2c, I2CConfig config)
+    Xl9535(const std::string& name, shared_ptr<MqttRoot> mqttRoot, std::shared_ptr<I2CManager> i2c, I2CConfig config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , component(name, mqttRoot, i2c, config) {
 
@@ -134,7 +134,7 @@ public:
         : PeripheralFactory<Xl9535DeviceConfig, EmptyConfiguration>("multiplexer:xl9535") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Xl9535DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Xl9535DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         return make_unique<Xl9535>(name, mqttRoot, services.i2c, deviceConfig->parse());
     }
 };

--- a/main/peripherals/multiplexer/Xl9535.hpp
+++ b/main/peripherals/multiplexer/Xl9535.hpp
@@ -134,8 +134,8 @@ public:
         : PeripheralFactory<Xl9535DeviceConfig, EmptyConfiguration>("multiplexer:xl9535") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const Xl9535DeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        return make_unique<Xl9535>(name, mqttRoot, services.i2c, deviceConfig.parse());
+    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Xl9535DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        return make_unique<Xl9535>(name, mqttRoot, services.i2c, deviceConfig->parse());
     }
 };
 

--- a/main/peripherals/multiplexer/Xl9535.hpp
+++ b/main/peripherals/multiplexer/Xl9535.hpp
@@ -74,7 +74,7 @@ private:
         device->writeRegByte(0x03, output >> 8);
     }
 
-    shared_ptr<I2CDevice> device;
+    std::shared_ptr<I2CDevice> device;
 
     uint16_t polarity = 0;
     uint16_t direction = 0xFFFF;
@@ -109,7 +109,7 @@ private:
 class Xl9535
     : public Peripheral<EmptyConfiguration> {
 public:
-    Xl9535(const std::string& name, shared_ptr<MqttRoot> mqttRoot, std::shared_ptr<I2CManager> i2c, I2CConfig config)
+    Xl9535(const std::string& name, std::shared_ptr<MqttRoot> mqttRoot, std::shared_ptr<I2CManager> i2c, I2CConfig config)
         : Peripheral<EmptyConfiguration>(name, mqttRoot)
         , component(name, mqttRoot, i2c, config) {
 
@@ -134,8 +134,8 @@ public:
         : PeripheralFactory<Xl9535DeviceConfig, EmptyConfiguration>("multiplexer:xl9535") {
     }
 
-    unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Xl9535DeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
-        return make_unique<Xl9535>(name, mqttRoot, services.i2c, deviceConfig->parse());
+    std::unique_ptr<Peripheral<EmptyConfiguration>> createPeripheral(const std::string& name, const std::shared_ptr<Xl9535DeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+        return std::make_unique<Xl9535>(name, mqttRoot, services.i2c, deviceConfig->parse());
     }
 };
 

--- a/main/peripherals/valve/Valve.hpp
+++ b/main/peripherals/valve/Valve.hpp
@@ -18,10 +18,6 @@
 #include <peripherals/valve/ValveScheduler.hpp>
 
 using namespace std::chrono;
-using std::make_unique;
-using std::move;
-using std::unique_ptr;
-
 using namespace farmhub::kernel::drivers;
 using namespace farmhub::peripherals;
 
@@ -33,7 +29,7 @@ public:
     Valve(
         const std::string& name,
         ValveControlStrategy& strategy,
-        shared_ptr<MqttRoot> mqttRoot)
+        std::shared_ptr<MqttRoot> mqttRoot)
         : Peripheral<ValveConfig>(name, mqttRoot)
         , valve(name, strategy, mqttRoot, [this]() {
             publishTelemetry();
@@ -67,9 +63,9 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<ValveConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ValveDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
+    std::unique_ptr<Peripheral<ValveConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ValveDeviceConfig> deviceConfig, std::shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         auto strategy = deviceConfig->createValveControlStrategy(this);
-        return make_unique<Valve>(name, *strategy, mqttRoot);
+        return std::make_unique<Valve>(name, *strategy, mqttRoot);
     }
 };
 

--- a/main/peripherals/valve/Valve.hpp
+++ b/main/peripherals/valve/Valve.hpp
@@ -67,7 +67,7 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<ValveConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ValveDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+    unique_ptr<Peripheral<ValveConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ValveDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, const PeripheralServices& services) override {
         auto strategy = deviceConfig->createValveControlStrategy(this);
         return make_unique<Valve>(name, *strategy, mqttRoot);
     }

--- a/main/peripherals/valve/Valve.hpp
+++ b/main/peripherals/valve/Valve.hpp
@@ -40,8 +40,8 @@ public:
         }) {
     }
 
-    void configure(const ValveConfig& config) override {
-        valve.setSchedules(config.schedule.get());
+    void configure(const std::shared_ptr<ValveConfig> config) override {
+        valve.setSchedules(config->schedule.get());
     }
 
     void populateTelemetry(JsonObject& telemetry) override {
@@ -67,8 +67,8 @@ public:
         , Motorized(motors) {
     }
 
-    unique_ptr<Peripheral<ValveConfig>> createPeripheral(const std::string& name, const ValveDeviceConfig& deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
-        auto strategy = deviceConfig.createValveControlStrategy(this);
+    unique_ptr<Peripheral<ValveConfig>> createPeripheral(const std::string& name, const std::shared_ptr<ValveDeviceConfig> deviceConfig, shared_ptr<MqttRoot> mqttRoot, PeripheralServices& services) override {
+        auto strategy = deviceConfig->createValveControlStrategy(this);
         return make_unique<Valve>(name, *strategy, mqttRoot);
     }
 };

--- a/main/peripherals/valve/ValveComponent.hpp
+++ b/main/peripherals/valve/ValveComponent.hpp
@@ -21,10 +21,6 @@
 #include <peripherals/valve/ValveScheduler.hpp>
 
 using namespace std::chrono;
-using std::make_unique;
-using std::move;
-using std::unique_ptr;
-
 using namespace farmhub::kernel::drivers;
 using namespace farmhub::peripherals;
 
@@ -201,7 +197,7 @@ public:
     ValveComponent(
         const std::string& name,
         ValveControlStrategy& strategy,
-        shared_ptr<MqttRoot> mqttRoot,
+        std::shared_ptr<MqttRoot> mqttRoot,
         std::function<void()> publishTelemetry)
         : Component(name, mqttRoot)
         , nvs(name)


### PR DESCRIPTION
Instead of using references and constructor-initialized stuff, let's do `std::shared_ptr` for all the stuff we want to pass around and init them in a sane order.

This is the first step of improving code organization.