### PR TITLE
Improve handling of incoming MQTT message processing timeout

### DIFF
--- a/data-templates/test-mk6.json
+++ b/data-templates/test-mk6.json
@@ -1,6 +1,5 @@
 {
   "instance": "test-mk6-xxx",
-  "id": "UD060x-xxx",
   "location": "bumblebee",
   "peripherals": [
     {

--- a/main/kernel/Task.hpp
+++ b/main/kernel/Task.hpp
@@ -62,12 +62,6 @@ public:
         }
     }
 
-    void abort() {
-        if (isValid()) {
-            vTaskDelete(handle);
-        }
-    }
-
 private:
     TaskHandle_t handle;
 };
@@ -95,26 +89,6 @@ public:
         OK,
         TIMEOUT,
     };
-
-    static RunResult inline runIn(const std::string& name, ticks timeout, uint32_t stackSize, const TaskFunction runFunction) {
-        return Task::runIn(name, timeout, stackSize, DEFAULT_PRIORITY, runFunction);
-    }
-    static RunResult runIn(const std::string& name, ticks timeout, uint32_t stackSize, UBaseType_t priority, const TaskFunction runFunction) {
-        TaskHandle_t caller = xTaskGetCurrentTaskHandle();
-        TaskHandle callee = run(name, stackSize, priority, [runFunction, caller](Task& task) {
-            runFunction(task);
-            xTaskNotifyGive(caller);
-        });
-        auto result = xTaskNotifyWait(0, 0, nullptr, timeout.count());
-        if (result == pdTRUE) {
-            return RunResult::OK;
-        } else {
-            callee.abort();
-            LOGV("Task '%s' timed out",
-                name.c_str());
-            return RunResult::TIMEOUT;
-        }
-    }
 
     static TaskHandle inline loop(const std::string& name, uint32_t stackSize, TaskFunction loopFunction) {
         return Task::loop(name, stackSize, DEFAULT_PRIORITY, loopFunction);

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -96,3 +96,6 @@ CONFIG_ESP_COREDUMP_LOGS=n
 
 # We don't need Ethernet
 CONFIG_ETH_USE_SPI_ETHERNET=n
+
+# Handle undelivered MQTT messages
+CONFIG_MQTT_REPORT_DELETED_MESSAGES=y


### PR DESCRIPTION
When an incoming message handling times out, we shouldn't abort the FreeRTOS task, because it can cause problems like #363.

Instead of having a hard deadline for the task and killing it, let's just trust the timeouts to work properly and handle things that way. This removes the whole question of having to deal with deleted tasks.

Fixes #363.