### PR TITLE
Do not re-allocate task function on stack

### DIFF
--- a/main/kernel/Task.hpp
+++ b/main/kernel/Task.hpp
@@ -195,12 +195,10 @@ private:
     }
 
     static void executeTask(void* parameters) {
-        TaskFunction* taskFunctionParam = static_cast<TaskFunction*>(parameters);
-        TaskFunction taskFunction(*taskFunctionParam);
-        delete taskFunctionParam;
-
+        auto taskFunction = static_cast<TaskFunction*>(parameters);
         Task task;
-        taskFunction(task);
+        (*taskFunction)(task);
+        delete taskFunction;
     }
 
     TickType_t lastWakeTime { xTaskGetTickCount() };


### PR DESCRIPTION
Previously we've copied the task's function from the heap to the stack of the task itself. This used up stack unnecessarily. Running task functions from the heap instead can save task stack size.