### PR TITLE
Report crashed firmware version in crash report

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -499,7 +499,7 @@ extern "C" void app_main() {
             json["peripherals"].to<JsonArray>().set(peripheralsInitJson);
             json["sleepWhenIdle"] = powerManager->sleepWhenIdle;
 
-            CrashManager::reportPreviousCrashIfAny(json);
+            CrashManager::handleCrashReport(json);
         },
         Retention::NoRetain, QoS::AtLeastOnce, 5s);
 


### PR DESCRIPTION
The SHA256 is nice, but getting the actual firmware version number can make it easier to look up the right ELF file for debugging.

Fixes #321.