### PR TITLE
Fix Watchdog not emitting cancelled event

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,4 +210,12 @@ After that from the "Run and Debug" panel select the "Wokwi GDB" configuration a
 
 ### Testing
 
-TBD
+To run unit tests using Wokwi:
+
+```bash
+$ cd test
+$ idf.py build
+$ pytest --embedded-services idf,wokwi .\pytest_catch2.py
+```
+
+Make sure to set the `WOKWI_CLI_TOKEN` environment variable.

--- a/components/kernel/CMakeLists.txt
+++ b/components/kernel/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(
     INCLUDE_DIRS "."
+    REQUIRES esp_timer
 )

--- a/components/kernel/Log.hpp
+++ b/components/kernel/Log.hpp
@@ -2,8 +2,6 @@
 
 #include <string>
 
-#include <ArduinoJson.h>
-
 #include <esp_log.h>
 
 namespace farmhub::kernel {
@@ -59,13 +57,6 @@ public:
 #define FARMHUB_LOG_LEVEL FARMHUB_LOG_LEVEL_INFO
 #endif
 #endif
-
-bool convertToJson(const Level& src, JsonVariant dst) {
-    return dst.set(static_cast<int>(src));
-}
-void convertFromJson(JsonVariantConst src, Level& dst) {
-    dst = static_cast<Level>(src.as<int>());
-}
 
 class Log {
 public:

--- a/components/kernel/LogJson.hpp
+++ b/components/kernel/LogJson.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <ArduinoJson.h>
+
+#include <Log.hpp>
+
+namespace farmhub::kernel {
+
+bool convertToJson(const Level& src, JsonVariant dst) {
+    return dst.set(static_cast<int>(src));
+}
+void convertFromJson(JsonVariantConst src, Level& dst) {
+    dst = static_cast<Level>(src.as<int>());
+}
+
+}    // namespace farmhub::kernel

--- a/components/kernel/Watchdog.hpp
+++ b/components/kernel/Watchdog.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 
 #include <esp_check.h>
+#include <esp_timer.h>
 
-#include <Time.hpp>
+#include <Log.hpp>
+
+using namespace std::chrono;
+using namespace std::chrono_literals;
 
 namespace farmhub::kernel {
 
@@ -56,7 +61,12 @@ public:
 
     bool cancel() {
         // TODO Add proper error handling
-        return esp_timer_stop(timer) == ESP_OK;
+        if (esp_timer_stop(timer) == ESP_OK) {
+            callback(WatchdogState::Cancelled);
+            return true;
+        } else {
+            return false;
+        }
     }
 
 private:

--- a/components/kernel/mqtt/MqttLog.hpp
+++ b/components/kernel/mqtt/MqttLog.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Log.hpp>
+#include <LogJson.hpp>
 #include <Task.hpp>
 #include <mqtt/MqttRoot.hpp>
 

--- a/components/kernel/test/WatchdogTest.cpp
+++ b/components/kernel/test/WatchdogTest.cpp
@@ -50,3 +50,15 @@ TEST_CASE("watchdog can time out") {
     vTaskDelay(20 / portTICK_PERIOD_MS);
     REQUIRE(watchdogState.value() == WatchdogState::TimedOut);
 }
+
+TEST_CASE("deleting watchdog cancels") {
+    std::optional<WatchdogState> watchdogState;
+    {
+        Watchdog watchdog("test", 1h, true, [&](WatchdogState state) {
+            watchdogState = state;
+        });
+        REQUIRE(watchdogState.value() == WatchdogState::Started);
+    }
+
+    REQUIRE(watchdogState.value() == WatchdogState::Cancelled);
+}

--- a/components/kernel/test/WatchdogTest.cpp
+++ b/components/kernel/test/WatchdogTest.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+
+#include <freertos/FreeRTOS.h>
+
+#include <Watchdog.hpp>
+
+using namespace farmhub::kernel;
+
+TEST_CASE("can start and stop watchdog") {
+    std::optional<WatchdogState> watchdogState;
+    Watchdog watchdog("test", 1h, false, [&](WatchdogState state) {
+        watchdogState = state;
+    });
+    REQUIRE(!watchdogState.has_value());
+
+    watchdog.restart();
+    REQUIRE(watchdogState.value() == WatchdogState::Started);
+
+    watchdog.cancel();
+    REQUIRE(watchdogState.value() == WatchdogState::Cancelled);
+
+    watchdog.restart();
+    REQUIRE(watchdogState.value() == WatchdogState::Started);
+
+    watchdog.cancel();
+    REQUIRE(watchdogState.value() == WatchdogState::Cancelled);
+}
+
+TEST_CASE("can create auto-starting watchdog") {
+    std::optional<WatchdogState> watchdogState;
+    Watchdog watchdog("test", 1h, true, [&](WatchdogState state) {
+        watchdogState = state;
+    });
+    REQUIRE(watchdogState.value() == WatchdogState::Started);
+
+    watchdog.cancel();
+    REQUIRE(watchdogState.value() == WatchdogState::Cancelled);
+}
+
+TEST_CASE("watchdog can time out") {
+    std::optional<WatchdogState> watchdogState;
+    Watchdog watchdog("test", 10ms, false, [&](WatchdogState state) {
+        watchdogState = state;
+    });
+    REQUIRE(!watchdogState.has_value());
+
+    watchdog.restart();
+    vTaskDelay(20 / portTICK_PERIOD_MS);
+    REQUIRE(watchdogState.value() == WatchdogState::TimedOut);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,4 +17,6 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # "Trim" the build. Include the minimal set of components, main, and anything it depends on.
 idf_build_set_property(MINIMAL_BUILD ON)
 
+add_compile_options("-Wno-missing-field-initializers")
+
 project(ugly-duckling-test)


### PR DESCRIPTION
This caused the chicken-door component to stop sleeping after moving the door.