### PR TITLE
More concise logging

### DIFF
--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -310,7 +310,7 @@ public:
                     throw ConfigurationException("Cannot open config file " + path + " (" + std::string(error.c_str()) + ")");
             }
             update(json.as<JsonObject>());
-            LOGI("Effective configuration for '%s': %s",
+            LOGD("Effective configuration for '%s': %s",
                 path.c_str(), toString().c_str());
         }
         onUpdate([fs, path](const JsonObject& json) {

--- a/components/kernel/Log.hpp
+++ b/components/kernel/Log.hpp
@@ -73,6 +73,12 @@ public:
             esp_log_level_set(tag, ESP_LOG_INFO);
 #endif
         }
+        // Prevent "esp_vfs_register_fd_range is successful for range" from spamming the logs
+        // TODO Remove once ESP-IDF 5.4.1(?) is released with https://github.com/espressif/esp-idf/issues/14327 fixed
+        esp_log_level_set("vfs", ESP_LOG_ERROR);
+        // Prevent "saving new calibration data because of checksum failure" from spamming the logs
+        // TODO Remove once ESP-IDF 5.4.1 is released with https://github.com/espressif/esp-idf/issues/14963 fixed
+        esp_log_level_set("phy_init", ESP_LOG_ERROR);
     }
 
 private:

--- a/components/kernel/PowerManager.hpp
+++ b/components/kernel/PowerManager.hpp
@@ -118,11 +118,11 @@ private:
     static bool shouldSleepWhenIdle(bool requestedSleepWhenIdle) {
         if (requestedSleepWhenIdle) {
 #if FARMHUB_DEBUG
-            LOGTW(Tag::PM, "Light sleep is disabled in debug mode");
+            LOGTI(Tag::PM, "Light sleep is disabled in debug mode");
             return false;
 #elif WOKWI
             // See https://github.com/wokwi/wokwi-features/issues/922
-            LOGTW(Tag::PM, "Light sleep is disabled when running under Wokwi");
+            LOGTI(Tag::PM, "Light sleep is disabled when running under Wokwi");
             return false;
 #elif not(CONFIG_PM_ENABLE)
             LOGTI(Tag::PM, "Power management is disabled because CONFIG_PM_ENABLE is not set");

--- a/components/kernel/mqtt/MqttDriver.hpp
+++ b/components/kernel/mqtt/MqttDriver.hpp
@@ -568,25 +568,38 @@ private:
                 break;
             }
             case MQTT_EVENT_ERROR: {
-                if (event->error_handle->error_type == MQTT_ERROR_TYPE_TCP_TRANSPORT) {
-                    LOGTE(Tag::MQTT, "Last errno string (%s)", strerror(event->error_handle->esp_transport_sock_errno));
-                    logErrorIfNonZero("reported from esp-tls", event->error_handle->esp_tls_last_esp_err);
-                    logErrorIfNonZero("reported from tls stack", event->error_handle->esp_tls_stack_err);
-                    logErrorIfNonZero("captured as transport's socket errno", event->error_handle->esp_transport_sock_errno);
+                switch (event->error_handle->error_type) {
+                    case MQTT_ERROR_TYPE_TCP_TRANSPORT:
+                        LOGTE(Tag::MQTT, "TCP transport error; transport socket errno: %d, TLS last ESP error: 0x%x, TLS stack error: 0x%x, TLS cert verify flags: 0x%x",
+                            event->error_handle->esp_transport_sock_errno,
+                            event->error_handle->esp_tls_last_esp_err,
+                            event->error_handle->esp_tls_stack_err,
+                            event->error_handle->esp_tls_cert_verify_flags);
+                        break;
+
+                    case MQTT_ERROR_TYPE_CONNECTION_REFUSED:
+                        LOGTE(Tag::MQTT, "Connection refused; return code: %d",
+                            event->error_handle->connect_return_code);
+                        break;
+
+                    case MQTT_ERROR_TYPE_SUBSCRIBE_FAILED:
+                        LOGTE(Tag::MQTT, "Subscribe failed; message ID: %d",
+                            event->msg_id);
+                        break;
+
+                    case MQTT_ERROR_TYPE_NONE:
+                        // Nothing to report
+                        break;
                 }
-                eventQueue.offerIn(MQTT_QUEUE_TIMEOUT, MessagePublished { event->msg_id, false });
+                if (event->msg_id != 0) {
+                    eventQueue.offerIn(MQTT_QUEUE_TIMEOUT, MessagePublished { event->msg_id, false });
+                }
                 break;
             }
             default: {
                 LOGTW(Tag::MQTT, "Unknown event %d", eventId);
                 break;
             }
-        }
-    }
-
-    static void logErrorIfNonZero(const char* message, int error) {
-        if (error != 0) {
-            LOGTE(Tag::MQTT, " - %s: 0x%x", message, error);
         }
     }
 

--- a/components/kernel/mqtt/MqttDriver.hpp
+++ b/components/kernel/mqtt/MqttDriver.hpp
@@ -570,7 +570,7 @@ private:
             case MQTT_EVENT_ERROR: {
                 switch (event->error_handle->error_type) {
                     case MQTT_ERROR_TYPE_TCP_TRANSPORT:
-                        LOGTE(Tag::MQTT, "TCP transport error; transport socket errno: %d, TLS last ESP error: 0x%x, TLS stack error: 0x%x, TLS cert verify flags: 0x%x",
+                        LOGTE(Tag::MQTT, "TCP transport error; esp_transport_sock_errno: %d, esp_tls_last_esp_err: 0x%x, esp_tls_stack_err: 0x%x, esp_tls_cert_verify_flags: 0x%x",
                             event->error_handle->esp_transport_sock_errno,
                             event->error_handle->esp_tls_last_esp_err,
                             event->error_handle->esp_tls_stack_err,


### PR DESCRIPTION
This temporarily removes a few superfluous warnings from ESP-IDF, logs light sleep status always at `INFO`, and file contents only at `DEBUG` (so they don't get published to the server).