### PR TITLE
On peripheral init problem throw exception instead of abort

### DIFF
--- a/components/peripherals/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/components/peripherals/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -55,7 +55,7 @@ public:
     void populateTelemetry(JsonObject& json) override {
         // TODO Get temperature in a task to avoid delaying reporting
         float temperature;
-        ESP_ERROR_CHECK(ds18x20_measure_and_read_multi(pin->getGpio(), &sensor, 1, &temperature));
+        ESP_PERIPHERAL_THROW(ds18x20_measure_and_read_multi(pin->getGpio(), &sensor, 1, &temperature));
         json["temperature"] = temperature;
     }
 

--- a/components/peripherals/peripherals/environment/Sht2xComponent.hpp
+++ b/components/peripherals/peripherals/environment/Sht2xComponent.hpp
@@ -39,7 +39,7 @@ public:
         LOGI("Initializing %s environment sensor with %s",
             sensorType.c_str(), config.toString().c_str());
 
-        ESP_ERROR_CHECK(si7021_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
+        ESP_PERIPHERAL_THROW(si7021_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
     }
 
     void populateTelemetry(JsonObject& json) override {

--- a/components/peripherals/peripherals/environment/Sht3xComponent.hpp
+++ b/components/peripherals/peripherals/environment/Sht3xComponent.hpp
@@ -36,8 +36,8 @@ public:
         LOGI("Initializing %s environment sensor with %s",
             sensorType.c_str(), config.toString().c_str());
 
-        ESP_ERROR_CHECK(sht3x_init_desc(&sensor, config.address, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
-        ESP_ERROR_CHECK(sht3x_init(&sensor));
+        ESP_PERIPHERAL_THROW(sht3x_init_desc(&sensor, config.address, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
+        ESP_PERIPHERAL_THROW(sht3x_init(&sensor));
     }
 
     void populateTelemetry(JsonObject& json) override {

--- a/components/peripherals/peripherals/light_sensor/Bh1750.hpp
+++ b/components/peripherals/peripherals/light_sensor/Bh1750.hpp
@@ -47,8 +47,8 @@ public:
             config.toString().c_str());
 
         // TODO Use I2CManager to create device
-        ESP_ERROR_CHECK(bh1750_init_desc(&sensor, config.address, I2C_NUM_0, config.sda->getGpio(), config.scl->getGpio()));
-        ESP_ERROR_CHECK(bh1750_setup(&sensor, BH1750_MODE_CONTINUOUS, BH1750_RES_LOW));
+        ESP_PERIPHERAL_THROW(bh1750_init_desc(&sensor, config.address, I2C_NUM_0, config.sda->getGpio(), config.scl->getGpio()));
+        ESP_PERIPHERAL_THROW(bh1750_setup(&sensor, BH1750_MODE_CONTINUOUS, BH1750_RES_LOW));
 
         runLoop();
     }

--- a/components/peripherals/peripherals/light_sensor/Tsl2591.hpp
+++ b/components/peripherals/peripherals/light_sensor/Tsl2591.hpp
@@ -47,14 +47,14 @@ public:
         LOGI("Initializing TSL2591 light sensor with %s",
             config.toString().c_str());
 
-        ESP_ERROR_CHECK(tsl2591_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
-        ESP_ERROR_CHECK(tsl2591_init(&sensor));
+        ESP_PERIPHERAL_THROW(tsl2591_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
+        ESP_PERIPHERAL_THROW(tsl2591_init(&sensor));
 
         // TODO Make these configurable
-        ESP_ERROR_CHECK(tsl2591_set_power_status(&sensor, TSL2591_POWER_ON));
-        ESP_ERROR_CHECK(tsl2591_set_als_status(&sensor, TSL2591_ALS_ON));
-        ESP_ERROR_CHECK(tsl2591_set_gain(&sensor, TSL2591_GAIN_MEDIUM));
-        ESP_ERROR_CHECK(tsl2591_set_integration_time(&sensor, TSL2591_INTEGRATION_300MS));
+        ESP_PERIPHERAL_THROW(tsl2591_set_power_status(&sensor, TSL2591_POWER_ON));
+        ESP_PERIPHERAL_THROW(tsl2591_set_als_status(&sensor, TSL2591_ALS_ON));
+        ESP_PERIPHERAL_THROW(tsl2591_set_gain(&sensor, TSL2591_GAIN_MEDIUM));
+        ESP_PERIPHERAL_THROW(tsl2591_set_integration_time(&sensor, TSL2591_INTEGRATION_300MS));
 
         runLoop();
     }


### PR DESCRIPTION
This makes it possible to handle ESP errors without the device crashing.