### PR TITLE
Fix status-2 LED blinking on MK7

### DIFF
--- a/components/devices/devices/UglyDucklingMk7.hpp
+++ b/components/devices/devices/UglyDucklingMk7.hpp
@@ -84,6 +84,10 @@ class UglyDucklingMk7 : public DeviceDefinition<Mk7Config> {
 public:
     UglyDucklingMk7(std::shared_ptr<Mk7Config> config)
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
+        // Switch off strapping pin
+        // TODO: Add a LED driver instead
+        pins::STATUS2->pinMode(Pin::Mode::Output);
+        pins::STATUS2->digitalWrite(1);
     }
 
     static std::shared_ptr<BatteryDriver> createBatteryDriver(std::shared_ptr<I2CManager> i2c) {

--- a/data-templates/test-mk7.json
+++ b/data-templates/test-mk7.json
@@ -1,0 +1,18 @@
+{
+  "instance": "test-mk7-xxx",
+  "location": "bumblebee",
+  "peripherals": [
+    {
+      "name": "flow-control-a",
+      "type": "flow-control",
+      "params": {
+        "valve": {
+          "motor": "a"
+        },
+        "flow-meter": {
+          "pin": "A1"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
It is connected to a pin that is left floating by default, and needs to be pulled low at boot to avoid blinking.