### PR TITLE
Send log messages exactly once over MQTT

### DIFF
--- a/components/kernel/mqtt/MqttLog.hpp
+++ b/components/kernel/mqtt/MqttLog.hpp
@@ -28,7 +28,7 @@ public:
                         json["level"] = level;
                         json["message"] = message;
                     },
-                    Retention::NoRetain, QoS::AtLeastOnce, 2s, LogPublish::Silent);
+                    Retention::NoRetain, QoS::ExactlyOnce, 2s, LogPublish::Silent);
             });
         });
     }


### PR DESCRIPTION
This should also prevent reordering of messages. The delivery will be somewhat slower, but since it happens on a background queue, it shouldn't matter much.