### PR TITLE
Report available frames for corrupted core-dump backtrace

### DIFF
--- a/components/kernel/CrashManager.hpp
+++ b/components/kernel/CrashManager.hpp
@@ -83,15 +83,16 @@ private:
 
 #ifdef __XTENSA__
         auto backtraceJson = json["backtrace"].to<JsonObject>();
+
         if (summary.exc_bt_info.corrupted) {
             LOGE("Backtrace corrupted, depth %lu", summary.exc_bt_info.depth);
             backtraceJson["corrupted"] = true;
-        } else {
-            auto framesJson = backtraceJson["frames"].to<JsonArray>();
-            for (int i = 0; i < summary.exc_bt_info.depth; i++) {
-                auto& frame = summary.exc_bt_info.bt[i];
-                framesJson.add("0x" + toHexString(frame));
-            }
+        }
+
+        auto framesJson = backtraceJson["frames"].to<JsonArray>();
+        for (int i = 0; i < summary.exc_bt_info.depth; i++) {
+            auto& frame = summary.exc_bt_info.bt[i];
+            framesJson.add("0x" + toHexString(frame));
         }
 #else
         size_t encodedLen = (summary.exc_bt_info.dump_size + 2) / 3 * 4 + 1;


### PR DESCRIPTION
We might have some valid frames even when the backtrace is corrupted.

We should be able to get at least the program counter's location:

https://github.com/espressif/esp-idf/blob/1c468f68259065ef51afd114605d9122f13d9d72/components/espcoredump/src/port/xtensa/core_dump_port.c#L539-L563