### PR TITLE
Handle peripheral initialization errors gracefully

### DIFF
--- a/components/kernel/DebugConsole.hpp
+++ b/components/kernel/DebugConsole.hpp
@@ -55,8 +55,8 @@ private:
             return "\033[0;33moff\033[0m";
         }
 
-        wifi_mode_t mode;
-        ESP_ERROR_CHECK(esp_wifi_get_mode(&mode));
+        wifi_mode_t mode = WIFI_MODE_NULL;
+        ESP_ERROR_CHECK_WITHOUT_ABORT(esp_wifi_get_mode(&mode));
 
         switch (mode) {
             case WIFI_MODE_STA:

--- a/components/kernel/EspException.hpp
+++ b/components/kernel/EspException.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <esp_err.h>
+#include <exception>
+
+namespace farmhub::kernel {
+
+class EspException
+    : public std::runtime_error {
+public:
+    explicit EspException(const std::string& reason)
+        : std::runtime_error(reason) {
+    }
+};
+
+#define ESP_ERROR_THROW(err)                                           \
+    do {                                                               \
+        esp_err_t _err_ = (err);                                       \
+        if (_err_ != ESP_OK) {                                         \
+            throw EspException(esp_err_to_name(_err_)); \
+        }                                                              \
+    } while (0)
+
+}    // namespace farmhub::kernel

--- a/components/kernel/I2CManager.hpp
+++ b/components/kernel/I2CManager.hpp
@@ -6,6 +6,7 @@
 #include <i2cdev.h>
 
 #include <Concurrent.hpp>
+#include <EspException.hpp>
 #include <Pin.hpp>
 #include <Strings.hpp>
 
@@ -68,30 +69,30 @@ public:
 
     uint8_t readRegByte(uint8_t reg) {
         uint8_t value;
-        ESP_ERROR_CHECK(i2c_dev_read(&device, &reg, 1, &value, 1));
+        ESP_ERROR_THROW(i2c_dev_read(&device, &reg, 1, &value, 1));
         return value;
     }
 
     uint16_t readRegWord(uint8_t reg) {
         uint16_t value;
-        ESP_ERROR_CHECK(i2c_dev_read(&device, &reg, 1, &value, 2));
+        ESP_ERROR_THROW(i2c_dev_read(&device, &reg, 1, &value, 2));
         return value;
     }
 
     void readReg(uint8_t reg, uint8_t* buffer, size_t length) {
-        ESP_ERROR_CHECK(i2c_dev_read(&device, &reg, 1, buffer, length));
+        ESP_ERROR_THROW(i2c_dev_read(&device, &reg, 1, buffer, length));
     }
 
     void writeRegByte(uint8_t reg, uint8_t value) {
-        ESP_ERROR_CHECK(i2c_dev_write(&device, &reg, 1, &value, 1));
+        ESP_ERROR_THROW(i2c_dev_write(&device, &reg, 1, &value, 1));
     }
 
     void writeRegWord(uint8_t reg, uint16_t value) {
-        ESP_ERROR_CHECK(i2c_dev_write(&device, &reg, 1, &value, 2));
+        ESP_ERROR_THROW(i2c_dev_write(&device, &reg, 1, &value, 2));
     }
 
     void writeReg(uint8_t reg, uint8_t* buffer, size_t length) {
-        ESP_ERROR_CHECK(i2c_dev_write(&device, &reg, 1, buffer, length));
+        ESP_ERROR_THROW(i2c_dev_write(&device, &reg, 1, buffer, length));
     }
 
 private:
@@ -104,7 +105,7 @@ private:
 class I2CManager {
 public:
     I2CManager() {
-        ESP_ERROR_CHECK(i2cdev_init());
+        ESP_ERROR_THROW(i2cdev_init());
         buses.reserve(I2C_NUM_MAX);
     }
 

--- a/components/kernel/PcntManager.hpp
+++ b/components/kernel/PcntManager.hpp
@@ -4,6 +4,8 @@
 
 #include <driver/pulse_cnt.h>
 
+#include <EspException.hpp>
+
 namespace farmhub::kernel {
 
 // TODO Limit number of channels available
@@ -53,13 +55,13 @@ public:
             .intr_priority = 0,
         };
         pcnt_unit_handle_t unit = nullptr;
-        ESP_ERROR_CHECK(pcnt_new_unit(&unitConfig, &unit));
+        ESP_ERROR_THROW(pcnt_new_unit(&unitConfig, &unit));
 
         if (maxGlitchDuration != 0ns) {
             pcnt_glitch_filter_config_t filterConfig = {
                 .max_glitch_ns = static_cast<uint32_t>(maxGlitchDuration.count()),
             };
-            ESP_ERROR_CHECK(pcnt_unit_set_glitch_filter(unit, &filterConfig));
+            ESP_ERROR_THROW(pcnt_unit_set_glitch_filter(unit, &filterConfig));
         }
 
         pcnt_chan_config_t channelConfig = {
@@ -67,12 +69,12 @@ public:
             .level_gpio_num = -1,
         };
         pcnt_channel_handle_t channel = nullptr;
-        ESP_ERROR_CHECK(pcnt_new_channel(unit, &channelConfig, &channel));
-        ESP_ERROR_CHECK(pcnt_channel_set_edge_action(channel, PCNT_CHANNEL_EDGE_ACTION_INCREASE, PCNT_CHANNEL_EDGE_ACTION_HOLD));
+        ESP_ERROR_THROW(pcnt_new_channel(unit, &channelConfig, &channel));
+        ESP_ERROR_THROW(pcnt_channel_set_edge_action(channel, PCNT_CHANNEL_EDGE_ACTION_INCREASE, PCNT_CHANNEL_EDGE_ACTION_HOLD));
 
-        ESP_ERROR_CHECK(pcnt_unit_enable(unit));
-        ESP_ERROR_CHECK(pcnt_unit_clear_count(unit));
-        ESP_ERROR_CHECK(pcnt_unit_start(unit));
+        ESP_ERROR_THROW(pcnt_unit_enable(unit));
+        ESP_ERROR_THROW(pcnt_unit_clear_count(unit));
+        ESP_ERROR_THROW(pcnt_unit_start(unit));
 
         LOGTD(Tag::PCNT, "Registered PCNT unit on pin %s",
             pin->getName().c_str());

--- a/components/kernel/Pin.hpp
+++ b/components/kernel/Pin.hpp
@@ -12,6 +12,8 @@
 
 #include <ArduinoJson.h>
 
+#include <EspException.hpp>
+
 namespace farmhub::kernel {
 
 class Pin;
@@ -113,7 +115,7 @@ public:
             .pull_down_en = mode == Mode::InputPullDown ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE,
         };
         gpio_sleep_set_direction(gpio, conf.mode);
-        ESP_ERROR_CHECK(gpio_config(&conf));
+        ESP_ERROR_THROW(gpio_config(&conf));
     }
 
     inline void digitalWrite(uint8_t val) const override {
@@ -139,7 +141,7 @@ public:
     AnalogPin(const InternalPinPtr pin)
         : pin(pin) {
         adc_unit_t unit;
-        ESP_ERROR_CHECK(adc_oneshot_io_to_channel(pin->getGpio(), &unit, &channel));
+        ESP_ERROR_THROW(adc_oneshot_io_to_channel(pin->getGpio(), &unit, &channel));
 
         handle = getUnitHandle(unit);
 
@@ -147,7 +149,7 @@ public:
             .atten = ADC_ATTEN_DB_12,
             .bitwidth = ADC_BITWIDTH_DEFAULT,
         };
-        ESP_ERROR_CHECK(adc_oneshot_config_channel(handle, channel, &config));
+        ESP_ERROR_THROW(adc_oneshot_config_channel(handle, channel, &config));
     }
 
     ~AnalogPin() {
@@ -167,7 +169,7 @@ public:
             case ESP_ERR_TIMEOUT:
                 return std::nullopt;
             default:
-                ESP_ERROR_CHECK(err);
+                ESP_ERROR_THROW(err);
                 // Won't get this far
                 abort();
         }
@@ -185,7 +187,7 @@ private:
                 .unit_id = unit,
                 .ulp_mode = ADC_ULP_MODE_DISABLE,
             };
-            ESP_ERROR_CHECK(adc_oneshot_new_unit(&config, &handle));
+            ESP_ERROR_THROW(adc_oneshot_new_unit(&config, &handle));
             ANALOG_UNITS[unit] = handle;
         }
         return handle;

--- a/components/kernel/PowerManager.hpp
+++ b/components/kernel/PowerManager.hpp
@@ -4,6 +4,7 @@
 
 #include <BootClock.hpp>
 #include <Concurrent.hpp>
+#include <EspException.hpp>
 #include <Telemetry.hpp>
 
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
@@ -21,7 +22,7 @@ class PowerManagementLock {
 public:
     PowerManagementLock(const std::string& name, esp_pm_lock_type_t type)
         : name(name) {
-        ESP_ERROR_CHECK(esp_pm_lock_create(type, 0, name.c_str(), &lock));
+        ESP_ERROR_THROW(esp_pm_lock_create(type, 0, name.c_str(), &lock));
     }
 
     ~PowerManagementLock() {
@@ -43,7 +44,7 @@ class PowerManagementLockGuard {
 public:
     PowerManagementLockGuard(PowerManagementLock& lock)
         : lock(lock) {
-        ESP_ERROR_CHECK(esp_pm_lock_acquire(lock.lock));
+        ESP_ERROR_THROW(esp_pm_lock_acquire(lock.lock));
     }
 
     ~PowerManagementLockGuard() {
@@ -72,7 +73,7 @@ public:
             .min_freq_mhz = MIN_CPU_FREQ_MHZ,
             .light_sleep_enable = sleepWhenIdle,
         };
-        ESP_ERROR_CHECK(esp_pm_configure(&pm_config));
+        ESP_ERROR_THROW(esp_pm_configure(&pm_config));
 
 #ifdef CONFIG_PM_LIGHT_SLEEP_CALLBACKS
         esp_pm_sleep_cbs_register_config_t cbs_conf = {
@@ -88,7 +89,7 @@ public:
             .enter_cb_prior = 0,
             .exit_cb_prior = 0,
         };
-        ESP_ERROR_CHECK(esp_pm_light_sleep_register_cbs(&cbs_conf));
+        ESP_ERROR_THROW(esp_pm_light_sleep_register_cbs(&cbs_conf));
 #endif
 
         //         Task::loop("power-manager", 4096, [this](Task& task) {

--- a/components/kernel/PulseCounter.hpp
+++ b/components/kernel/PulseCounter.hpp
@@ -39,16 +39,16 @@ public:
             .pull_down_en = GPIO_PULLDOWN_ENABLE,
             .intr_type = GPIO_INTR_ANYEDGE,
         };
-        ESP_ERROR_CHECK(gpio_config(&config));
+        ESP_ERROR_THROW(gpio_config(&config));
 
         // Use the same configuration while in light sleep
-        ESP_ERROR_CHECK(gpio_sleep_sel_dis(gpio));
+        ESP_ERROR_THROW(gpio_sleep_sel_dis(gpio));
 
         // TODO Where should this be called?
-        ESP_ERROR_CHECK(esp_sleep_enable_gpio_wakeup());
+        ESP_ERROR_THROW(esp_sleep_enable_gpio_wakeup());
 
         // Attach the ISR handler to the GPIO pin
-        ESP_ERROR_CHECK(gpio_isr_handler_add(gpio, interruptHandler, this));
+        ESP_ERROR_THROW(gpio_isr_handler_add(gpio, interruptHandler, this));
 
         LOGTD(Tag::PCNT, "Registered interrupt-based pulse counter unit on pin %s",
             pin->getName().c_str());
@@ -112,7 +112,7 @@ private:
                 sleepLock.emplace(PowerManager::noLightSleep, boot_clock::now());
 
                 // Make sure we wake up again to check for the opposing edge
-                ESP_ERROR_CHECK(gpio_wakeup_enable(
+                ESP_ERROR_THROW(gpio_wakeup_enable(
                     pin->getGpio(),
                     lastEdge == EdgeKind::Rising
                         ? GPIO_INTR_LOW_LEVEL
@@ -177,7 +177,7 @@ public:
                 return ESP_OK; },
                 .exit_cb_user_arg = this,
             };
-            ESP_ERROR_CHECK(esp_pm_light_sleep_register_cbs(&sleepCallbackConfig));
+            ESP_ERROR_THROW(esp_pm_light_sleep_register_cbs(&sleepCallbackConfig));
         }
 
         auto counter = std::make_shared<PulseCounter>(pin);

--- a/components/kernel/PwmManager.hpp
+++ b/components/kernel/PwmManager.hpp
@@ -24,7 +24,7 @@ public:
             .freq_hz = freqHz,
             .clk_cfg = clkSrc,
         };
-        ESP_ERROR_CHECK(ledc_timer_config(&config));
+        ESP_ERROR_THROW(ledc_timer_config(&config));
     }
 
     ~LedcTimer() {
@@ -66,7 +66,7 @@ public:
             .duty = 0,    // Set duty to 0%
             .hpoint = 0
         };
-        ESP_ERROR_CHECK(ledc_channel_config(&config));
+        ESP_ERROR_THROW(ledc_channel_config(&config));
     }
 
     uint32_t constexpr maxValue() const {
@@ -74,8 +74,8 @@ public:
     }
 
     void write(uint32_t value) const {
-        ESP_ERROR_CHECK(ledc_set_duty(timer.speedMode, channel, value));
-        ESP_ERROR_CHECK(ledc_update_duty(timer.speedMode, channel));
+        ESP_ERROR_THROW(ledc_set_duty(timer.speedMode, channel, value));
+        ESP_ERROR_THROW(ledc_update_duty(timer.speedMode, channel));
     }
 
     const std::string& getName() const {

--- a/components/peripherals/peripherals/Peripheral.hpp
+++ b/components/peripherals/peripherals/Peripheral.hpp
@@ -3,10 +3,9 @@
 #include <map>
 #include <memory>
 
-#include <esp_err.h>
-
 #include <BootClock.hpp>
 #include <Configuration.hpp>
+#include <EspException.hpp>
 #include <I2CManager.hpp>
 #include <Named.hpp>
 #include <PcntManager.hpp>
@@ -92,14 +91,6 @@ public:
         : std::runtime_error(reason) {
     }
 };
-
-#define ESP_PERIPHERAL_THROW(err)                                      \
-    do {                                                               \
-        esp_err_t _err_ = (err);                                       \
-        if (_err_ != ESP_OK) {                                         \
-            throw PeripheralCreationException(esp_err_to_name(_err_)); \
-        }                                                              \
-    } while (0)
 
 struct PeripheralServices {
     const std::shared_ptr<I2CManager> i2c;

--- a/components/peripherals/peripherals/chicken_door/ChickenDoor.hpp
+++ b/components/peripherals/peripherals/chicken_door/ChickenDoor.hpp
@@ -467,7 +467,7 @@ public:
             } else {
                 throw PeripheralCreationException("Unknown light sensor type: " + lightSensorType);
             }
-        } catch (const PeripheralCreationException& e) {
+        } catch (const std::exception& e) {
             LOGE("Could not initialize light sensor because %s", e.what());
             LOGW("Initializing without a light sensor");
             // TODO Do not pass I2C parameters to NoLightSensorComponent

--- a/components/peripherals/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/components/peripherals/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -55,7 +55,7 @@ public:
     void populateTelemetry(JsonObject& json) override {
         // TODO Get temperature in a task to avoid delaying reporting
         float temperature;
-        ESP_PERIPHERAL_THROW(ds18x20_measure_and_read_multi(pin->getGpio(), &sensor, 1, &temperature));
+        ESP_ERROR_THROW(ds18x20_measure_and_read_multi(pin->getGpio(), &sensor, 1, &temperature));
         json["temperature"] = temperature;
     }
 

--- a/components/peripherals/peripherals/environment/Sht2xComponent.hpp
+++ b/components/peripherals/peripherals/environment/Sht2xComponent.hpp
@@ -39,7 +39,7 @@ public:
         LOGI("Initializing %s environment sensor with %s",
             sensorType.c_str(), config.toString().c_str());
 
-        ESP_PERIPHERAL_THROW(si7021_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
+        ESP_ERROR_THROW(si7021_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
     }
 
     void populateTelemetry(JsonObject& json) override {

--- a/components/peripherals/peripherals/environment/Sht3xComponent.hpp
+++ b/components/peripherals/peripherals/environment/Sht3xComponent.hpp
@@ -36,8 +36,8 @@ public:
         LOGI("Initializing %s environment sensor with %s",
             sensorType.c_str(), config.toString().c_str());
 
-        ESP_PERIPHERAL_THROW(sht3x_init_desc(&sensor, config.address, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
-        ESP_PERIPHERAL_THROW(sht3x_init(&sensor));
+        ESP_ERROR_THROW(sht3x_init_desc(&sensor, config.address, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
+        ESP_ERROR_THROW(sht3x_init(&sensor));
     }
 
     void populateTelemetry(JsonObject& json) override {

--- a/components/peripherals/peripherals/light_sensor/Bh1750.hpp
+++ b/components/peripherals/peripherals/light_sensor/Bh1750.hpp
@@ -47,8 +47,8 @@ public:
             config.toString().c_str());
 
         // TODO Use I2CManager to create device
-        ESP_PERIPHERAL_THROW(bh1750_init_desc(&sensor, config.address, I2C_NUM_0, config.sda->getGpio(), config.scl->getGpio()));
-        ESP_PERIPHERAL_THROW(bh1750_setup(&sensor, BH1750_MODE_CONTINUOUS, BH1750_RES_LOW));
+        ESP_ERROR_THROW(bh1750_init_desc(&sensor, config.address, I2C_NUM_0, config.sda->getGpio(), config.scl->getGpio()));
+        ESP_ERROR_THROW(bh1750_setup(&sensor, BH1750_MODE_CONTINUOUS, BH1750_RES_LOW));
 
         runLoop();
     }

--- a/components/peripherals/peripherals/light_sensor/Tsl2591.hpp
+++ b/components/peripherals/peripherals/light_sensor/Tsl2591.hpp
@@ -47,14 +47,14 @@ public:
         LOGI("Initializing TSL2591 light sensor with %s",
             config.toString().c_str());
 
-        ESP_PERIPHERAL_THROW(tsl2591_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
-        ESP_PERIPHERAL_THROW(tsl2591_init(&sensor));
+        ESP_ERROR_THROW(tsl2591_init_desc(&sensor, bus->port, bus->sda->getGpio(), bus->scl->getGpio()));
+        ESP_ERROR_THROW(tsl2591_init(&sensor));
 
         // TODO Make these configurable
-        ESP_PERIPHERAL_THROW(tsl2591_set_power_status(&sensor, TSL2591_POWER_ON));
-        ESP_PERIPHERAL_THROW(tsl2591_set_als_status(&sensor, TSL2591_ALS_ON));
-        ESP_PERIPHERAL_THROW(tsl2591_set_gain(&sensor, TSL2591_GAIN_MEDIUM));
-        ESP_PERIPHERAL_THROW(tsl2591_set_integration_time(&sensor, TSL2591_INTEGRATION_300MS));
+        ESP_ERROR_THROW(tsl2591_set_power_status(&sensor, TSL2591_POWER_ON));
+        ESP_ERROR_THROW(tsl2591_set_als_status(&sensor, TSL2591_ALS_ON));
+        ESP_ERROR_THROW(tsl2591_set_gain(&sensor, TSL2591_GAIN_MEDIUM));
+        ESP_ERROR_THROW(tsl2591_set_integration_time(&sensor, TSL2591_INTEGRATION_300MS));
 
         runLoop();
     }


### PR DESCRIPTION
Instead of crashing the firmware during peripheral initialization if e.g. a non-analog-capable pin is configured as an analog pin, we now throw an exception that can be handled gracefully and reported. The device can still boot up all other peripherals, too.