### PR TITLE
Fix `ipc0` task crashing when pulse counter is active

### DIFF
--- a/components/kernel/Concurrent.hpp
+++ b/components/kernel/Concurrent.hpp
@@ -35,7 +35,7 @@ public:
 protected:
     const std::string name;
 
-    QueueHandle_t getQueueHandle() const {
+    constexpr IRAM_ATTR QueueHandle_t getQueueHandle() const {
         return queue;
     }
 

--- a/components/kernel/MovingAverage.hpp
+++ b/components/kernel/MovingAverage.hpp
@@ -28,7 +28,7 @@ public:
         currentIndex = (currentIndex + 1) % maxMeasurements;
     }
 
-    T getAverage() const {
+    constexpr T getAverage() const {
         return average;
     }
 

--- a/components/kernel/Pin.hpp
+++ b/components/kernel/Pin.hpp
@@ -51,7 +51,7 @@ public:
 
     virtual int digitalRead() const = 0;
 
-    const std::string& getName() const {
+    constexpr const std::string& getName() const {
         return name;
     }
 
@@ -128,7 +128,7 @@ public:
         return gpio_get_level(gpio);
     }
 
-    gpio_num_t getGpio() const {
+    constexpr IRAM_ATTR gpio_num_t getGpio() const {
         return gpio;
     }
 
@@ -177,7 +177,7 @@ public:
         }
     }
 
-    const std::string& getName() const {
+    constexpr const std::string& getName() const {
         return pin->getName();
     }
 

--- a/components/kernel/drivers/SwitchManager.hpp
+++ b/components/kernel/drivers/SwitchManager.hpp
@@ -136,7 +136,9 @@ private:
 // ISR handler for GPIO interrupt
 static void IRAM_ATTR handleSwitchInterrupt(void* arg) {
     auto* state = static_cast<SwitchManager::SwitchState*>(arg);
-    bool engaged = state->pin->digitalRead() == (state->mode == SwitchMode::PullUp ? 0 : 1);
+    // Must use gpio_get_level() to read the pin state instead of pin->digitalRead()
+    // because we cannot call virtual methods from an ISR
+    bool engaged = gpio_get_level(state->pin->getGpio()) == (state->mode == SwitchMode::PullUp ? 0 : 1);
     state->manager->queueSwitchStateChange(state, engaged);
 }
 

--- a/components/peripherals/peripherals/valve/ValveSchedule.hpp
+++ b/components/peripherals/peripherals/valve/ValveSchedule.hpp
@@ -20,15 +20,15 @@ public:
         , duration(duration) {
     }
 
-    time_point<system_clock> getStart() const {
+    constexpr time_point<system_clock> getStart() const {
         return start;
     }
 
-    seconds getPeriod() const {
+    constexpr seconds getPeriod() const {
         return period;
     }
 
-    seconds getDuration() const {
+    constexpr seconds getDuration() const {
         return duration;
     }
 


### PR DESCRIPTION
Fixes #415.