### PR TITLE
Fix pulse counter crash, again

### DIFF
--- a/components/devices/Device.hpp
+++ b/components/devices/Device.hpp
@@ -302,7 +302,7 @@ static void startDevice() {
     initNvsFlash();
 
     // Install GPIO ISR service
-    ESP_ERROR_CHECK(gpio_install_isr_service(ESP_INTR_FLAG_IRAM));
+    ESP_ERROR_CHECK(gpio_install_isr_service(0));
 
 #ifdef CONFIG_HEAP_TRACING
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));

--- a/components/devices/Device.hpp
+++ b/components/devices/Device.hpp
@@ -302,7 +302,7 @@ static void startDevice() {
     initNvsFlash();
 
     // Install GPIO ISR service
-    gpio_install_isr_service(0);
+    ESP_ERROR_CHECK(gpio_install_isr_service(ESP_INTR_FLAG_IRAM));
 
 #ifdef CONFIG_HEAP_TRACING
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));

--- a/components/devices/Device.hpp
+++ b/components/devices/Device.hpp
@@ -348,7 +348,7 @@ static void startDevice() {
 
     // Init switch and button handling
     auto switches = std::make_shared<SwitchManager>();
-    switches->onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [statusLed](const Switch&, milliseconds duration) {
+    switches->onReleased("factory-reset", deviceDefinition->bootPin, SwitchMode::PullUp, [statusLed](const std::shared_ptr<Switch>&, milliseconds duration) {
         if (duration >= 15s) {
             LOGI("Factory reset triggered after %lld ms", duration.count());
             performFactoryReset(statusLed, true);

--- a/components/kernel/CrashManager.hpp
+++ b/components/kernel/CrashManager.hpp
@@ -76,16 +76,19 @@ private:
         json["pc"] = "0x" + toHexString(summary.exc_pc);
 #if __XTENSA__
         // TODO Add more fields for Xtensa
-        json["exc-vaddr"] = "0x" + toHexString(summary.ex_info.exc_vaddr);
 #else
         // TODO Add more fields for RISC-V
 #endif
 
         static constexpr size_t PANIC_REASON_SIZE = 256;
         char panicReason[PANIC_REASON_SIZE];
-        if (esp_core_dump_get_panic_reason(panicReason, PANIC_REASON_SIZE) == ESP_OK) {
+        esp_err_t panicReasonGetErr = esp_core_dump_get_panic_reason(panicReason, PANIC_REASON_SIZE);
+        if (panicReasonGetErr == ESP_OK) {
             LOGD("Panic reason: %s", panicReason);
             json["panicReason"] = std::string(panicReason);
+        } else {
+            LOGI("Failed to get panic reason: %s", esp_err_to_name(panicReasonGetErr));
+            json["panicReasonErr"] = esp_err_to_name(panicReasonGetErr);
         }
 
 #ifdef __XTENSA__

--- a/components/kernel/CrashManager.hpp
+++ b/components/kernel/CrashManager.hpp
@@ -83,12 +83,17 @@ private:
         static constexpr size_t PANIC_REASON_SIZE = 256;
         char panicReason[PANIC_REASON_SIZE];
         esp_err_t panicReasonGetErr = esp_core_dump_get_panic_reason(panicReason, PANIC_REASON_SIZE);
-        if (panicReasonGetErr == ESP_OK) {
-            LOGD("Panic reason: %s", panicReason);
-            json["panicReason"] = std::string(panicReason);
-        } else {
-            LOGI("Failed to get panic reason: %s", esp_err_to_name(panicReasonGetErr));
-            json["panicReasonErr"] = esp_err_to_name(panicReasonGetErr);
+        switch (panicReasonGetErr) {
+            case ESP_OK:
+                LOGD("Panic reason: %s", panicReason);
+                json["panicReason"] = std::string(panicReason);
+                break;
+            case ESP_ERR_NOT_FOUND:
+                LOGD("No panic reason found");
+                break;
+            default:
+                LOGI("Failed to get panic reason: %s", esp_err_to_name(panicReasonGetErr));
+                json["panicReasonErr"] = esp_err_to_name(panicReasonGetErr);
         }
 
 #ifdef __XTENSA__

--- a/components/kernel/CrashManager.hpp
+++ b/components/kernel/CrashManager.hpp
@@ -72,6 +72,14 @@ private:
         json["elf-sha256"] = std::string(reinterpret_cast<const char*>(summary.app_elf_sha256));
         json["task"] = std::string(summary.exc_task);
         json["cause"] = excCause;
+        json["tcb"] = "0x" + toHexString(summary.exc_tcb);
+        json["pc"] = "0x" + toHexString(summary.exc_pc);
+#if __XTENSA__
+        // TODO Add more fields for Xtensa
+        json["exc-vaddr"] = "0x" + toHexString(summary.ex_info.exc_vaddr);
+#else
+        // TODO Add more fields for RISC-V
+#endif
 
         static constexpr size_t PANIC_REASON_SIZE = 256;
         char panicReason[PANIC_REASON_SIZE];

--- a/components/kernel/PcntManager.hpp
+++ b/components/kernel/PcntManager.hpp
@@ -9,6 +9,12 @@
 
 namespace farmhub::kernel {
 
+/**
+ * @brief Counts pulses on a GPIO pin using the Pulse Counter (PCNT) peripheral.
+ *
+ * Note: This counter is NOT safe to use with the device entering and exiting light sleep.
+ * If that behavior is desired, use `PulseCounter` instead.
+ */
 // TODO Limit number of channels available
 struct PulseCounterUnit {
     PulseCounterUnit(pcnt_unit_handle_t unit, InternalPinPtr pin)

--- a/components/kernel/Pin.hpp
+++ b/components/kernel/Pin.hpp
@@ -128,6 +128,14 @@ public:
         return gpio_get_level(gpio);
     }
 
+    IRAM_ATTR void digitalWriteFromISR(uint8_t val) const {
+        gpio_set_level(gpio, val);
+    }
+
+    IRAM_ATTR int digitalReadFromISR() const {
+        return gpio_get_level(gpio);
+    }
+
     constexpr IRAM_ATTR gpio_num_t getGpio() const {
         return gpio;
     }

--- a/components/kernel/drivers/SwitchManager.hpp
+++ b/components/kernel/drivers/SwitchManager.hpp
@@ -108,6 +108,8 @@ private:
     private:
         std::string name;
         InternalPinPtr pin;
+        // ISR-safe GPIO number
+        gpio_num_t gpio = pin->getGpio();
         SwitchMode mode;
 
         SwitchEngagementHandler engagementHandler;
@@ -138,7 +140,7 @@ static void IRAM_ATTR handleSwitchInterrupt(void* arg) {
     auto* state = static_cast<SwitchManager::SwitchState*>(arg);
     // Must use gpio_get_level() to read the pin state instead of pin->digitalRead()
     // because we cannot call virtual methods from an ISR
-    bool engaged = gpio_get_level(state->pin->getGpio()) == (state->mode == SwitchMode::PullUp ? 0 : 1);
+    bool engaged = gpio_get_level(state->gpio) == (state->mode == SwitchMode::PullUp ? 0 : 1);
     state->manager->queueSwitchStateChange(state, engaged);
 }
 

--- a/components/kernel/drivers/SwitchManager.hpp
+++ b/components/kernel/drivers/SwitchManager.hpp
@@ -94,8 +94,8 @@ public:
         }
 
         // Install GPIO ISR
-        gpio_set_intr_type(pin->getGpio(), GPIO_INTR_ANYEDGE);
-        gpio_isr_handler_add(pin->getGpio(), handleSwitchInterrupt, switchState.get());
+        ESP_ERROR_THROW(gpio_isr_handler_add(pin->getGpio(), handleSwitchInterrupt, switchState.get()));
+        ESP_ERROR_THROW(gpio_set_intr_type(pin->getGpio(), GPIO_INTR_ANYEDGE));
 
         return switchState;
     }

--- a/components/peripherals/peripherals/chicken_door/ChickenDoor.hpp
+++ b/components/peripherals/peripherals/chicken_door/ChickenDoor.hpp
@@ -135,24 +135,22 @@ public:
               name + ":open",
               openPin,
               SwitchMode::PullUp,
-              [this](const Switch&) { updateState(); },
-              [this](const Switch&, milliseconds) { updateState(); }))
+              [this](const std::shared_ptr<Switch>&) { updateState(); },
+              [this](const std::shared_ptr<Switch>&, milliseconds) { updateState(); }))
         , closedSwitch(switches->registerHandler(
               name + ":closed",
               closedPin,
               SwitchMode::PullUp,
-              [this](const Switch&) { updateState(); },
-              [this](const Switch&, milliseconds) { updateState(); }))
+              [this](const std::shared_ptr<Switch>&) { updateState(); },
+              [this](const std::shared_ptr<Switch>&, milliseconds) { updateState(); }))
         , invertSwitches(invertSwitches)
         , watchdog(name + ":watchdog", movementTimeout, false, [this](WatchdogState state) {
             handleWatchdogEvent(state);
         })
-        , publishTelemetry(std::move(publishTelemetry))
-    // TODO Make this configurable
-    {
+        , publishTelemetry(std::move(publishTelemetry)) {
 
         LOGI("Initializing chicken door %s, open switch %s, close switch %s%s",
-            name.c_str(), openSwitch.getPin()->getName().c_str(), closedSwitch.getPin()->getName().c_str(),
+            name.c_str(), openSwitch->getPin()->getName().c_str(), closedSwitch->getPin()->getName().c_str(),
             invertSwitches ? " (switches are inverted)" : "");
 
         motor->stop();
@@ -309,8 +307,8 @@ private:
     }
 
     DoorState determineCurrentState() {
-        bool open = openSwitch.isEngaged() ^ invertSwitches;
-        bool close = closedSwitch.isEngaged() ^ invertSwitches;
+        bool open = openSwitch->isEngaged() ^ invertSwitches;
+        bool close = closedSwitch->isEngaged() ^ invertSwitches;
         if (open && close) {
             LOGD("Both open and close switches are engaged");
             return DoorState::NONE;
@@ -352,8 +350,8 @@ private:
     double openLevel = std::numeric_limits<double>::max();
     double closeLevel = std::numeric_limits<double>::min();
 
-    const Switch& openSwitch;
-    const Switch& closedSwitch;
+    const std::shared_ptr<Switch> openSwitch;
+    const std::shared_ptr<Switch> closedSwitch;
     const bool invertSwitches;
 
     Watchdog watchdog;


### PR DESCRIPTION
Fixes #415 (again).

Looks like the problem was that once the device entered light-sleep we changed the interrupt to trigger on level. This meant that even when the device was awake, it was triggering on a specific level instead of on edge. Which meant that if the device was kept away for > 1s, it would generate a _lot_ of interrupts, and task scheduling would be starved, causing the task watchdog to fire.

This is now fixed by properly switching between level and edge detection as the device transitions in and out of light-sleep.

It also allowed a massive simplification of the counter logic.