### PR TITLE
Increase MQTT message resend timeout

### DIFF
--- a/components/kernel/mqtt/MqttDriver.hpp
+++ b/components/kernel/mqtt/MqttDriver.hpp
@@ -17,6 +17,7 @@
 #include <State.hpp>
 #include <Task.hpp>
 #include <drivers/MdnsDriver.hpp>
+#include <mqtt/PendingMessages.hpp>
 
 using namespace std::chrono_literals;
 using namespace farmhub::kernel;
@@ -38,14 +39,6 @@ enum class QoS : uint8_t {
 enum class LogPublish : uint8_t {
     Log,
     Silent
-};
-
-enum class PublishStatus : uint8_t {
-    TimeOut = 0,
-    Success = 1,
-    Failed = 2,
-    Pending = 3,
-    QueueFull = 4
 };
 
 using CommandHandler = std::function<void(const JsonObject&, JsonObject&)>;
@@ -191,13 +184,13 @@ public:
         }
     }
 
+private:
     static constexpr milliseconds MQTT_NETWORK_TIMEOUT = 15s;
     static constexpr milliseconds MQTT_CONNECTION_TIMEOUT = MQTT_NETWORK_TIMEOUT;
     static constexpr milliseconds MQTT_SESSION_KEEP_ALIVE = 120s;
     static constexpr milliseconds MQTT_LOOP_INTERVAL = 1s;
     static constexpr milliseconds MQTT_QUEUE_TIMEOUT = 1s;
 
-private:
     struct PendingSubscription {
         const int messageId;
         const time_point<boot_clock> subscribedAt;
@@ -291,14 +284,13 @@ private:
         }
 
         // Wait for task notification
-        uint32_t status = ulTaskNotifyTake(pdTRUE, timeout.count());
+        auto status = static_cast<PublishStatus>(ulTaskNotifyTake(pdTRUE, timeout.count()));
         switch (status) {
-            case 0:
+            case PublishStatus::TimeOut:
                 pendingMessages.cancelWaitingOn(waitingTask);
                 return PublishStatus::TimeOut;
-            case PUBLISH_SUCCESS:
+            case PublishStatus::Success:
                 return PublishStatus::Success;
-            case PUBLISH_FAILED:
             default:
                 return PublishStatus::Failed;
         }
@@ -329,78 +321,6 @@ private:
         Disconnected,
         Connecting,
         Connected,
-    };
-    class PendingMessages {
-    public:
-        bool waitOn(int messageId, TaskHandle_t waitingTask) {
-            if (waitingTask == nullptr) {
-                // Nothing is waiting
-                return false;
-            }
-
-            if (messageId == 0) {
-                // Notify tasks waiting on QoS 0 messages immediately
-                notifyWaitingTask(waitingTask, true);
-                return false;
-            }
-
-            // Record pending task
-            Lock lock(mutex);
-            messages[messageId] = waitingTask;
-            return true;
-        }
-
-        bool handlePublished(int messageId, bool success) {
-            if (messageId == 0) {
-                return false;
-            }
-
-            Lock lock(mutex);
-            auto it = messages.find(messageId);
-            if (it != messages.end()) {
-                notifyWaitingTask(it->second, success);
-                messages.erase(it);
-                return true;
-            }
-            return false;
-        }
-
-        bool cancelWaitingOn(TaskHandle_t waitingTask) {
-            if (waitingTask == nullptr) {
-                return false;
-            }
-
-            Lock lock(mutex);
-            bool removed = false;
-            for (auto it = messages.begin(); it != messages.end();) {
-                if (it->second == waitingTask) {
-                    it = messages.erase(it);
-                    removed = true;
-                } else {
-                    ++it;
-                }
-            }
-            return removed;
-        }
-
-        void clear() {
-            Lock lock(mutex);
-            for (auto& [messageId, waitingTask] : messages) {
-                notifyWaitingTask(waitingTask, false);
-            }
-            messages.clear();
-        }
-
-        static void notifyWaitingTask(TaskHandle_t task, bool success) {
-            if (task != nullptr) {
-                uint32_t status = success ? PUBLISH_SUCCESS : PUBLISH_FAILED;
-                xTaskNotify(task, status, eSetValueWithOverwrite);
-            }
-        }
-
-    private:
-        Mutex mutex;
-        std::unordered_map<int, TaskHandle_t> messages;
     };
 
     void runEventLoop(Task& /*task*/) {
@@ -798,9 +718,6 @@ private:
     // TODO Use a map instead
     std::list<Subscription> subscriptions;
     PendingMessages pendingMessages;
-
-    static constexpr uint32_t PUBLISH_SUCCESS = 1;
-    static constexpr uint32_t PUBLISH_FAILED = 2;
 
     friend class MqttRoot;
 };

--- a/components/kernel/mqtt/MqttDriver.hpp
+++ b/components/kernel/mqtt/MqttDriver.hpp
@@ -146,7 +146,7 @@ public:
                 .keepalive = duration_cast<seconds>(MQTT_SESSION_KEEP_ALIVE).count(),
                 .disable_keepalive = false,
                 .protocol_ver = MQTT_PROTOCOL_UNDEFINED,    // Default MQTT version
-                .message_retransmit_timeout = 0,            // Default retransmit timeout
+                .message_retransmit_timeout = duration_cast<milliseconds>(MQTT_MESSAGE_RETRANSMIT_TIMEOUT).count(),
             },
             .network {
                 .reconnect_timeout_ms = duration_cast<milliseconds>(MQTT_CONNECTION_TIMEOUT).count(),
@@ -186,6 +186,7 @@ public:
 
 private:
     static constexpr milliseconds MQTT_NETWORK_TIMEOUT = 15s;
+    static constexpr milliseconds MQTT_MESSAGE_RETRANSMIT_TIMEOUT = 5s;
     static constexpr milliseconds MQTT_CONNECTION_TIMEOUT = MQTT_NETWORK_TIMEOUT;
     static constexpr milliseconds MQTT_SESSION_KEEP_ALIVE = 120s;
     static constexpr milliseconds MQTT_LOOP_INTERVAL = 1s;

--- a/components/kernel/mqtt/PendingMessages.hpp
+++ b/components/kernel/mqtt/PendingMessages.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <unordered_map>
+
+#include <Concurrent.hpp>
+#include <Task.hpp>
+
+namespace farmhub::kernel::mqtt {
+
+enum class PublishStatus : uint8_t {
+    TimeOut = 0,
+    Success = 1,
+    Failed = 2,
+    Pending = 3,
+    QueueFull = 4
+};
+
+static constexpr uint32_t PUBLISH_SUCCESS = 1;
+static constexpr uint32_t PUBLISH_FAILED = 2;
+
+class PendingMessages {
+public:
+    bool waitOn(int messageId, TaskHandle_t waitingTask) {
+        if (waitingTask == nullptr) {
+            // Nothing is waiting
+            return false;
+        }
+
+        if (messageId == 0) {
+            // Notify tasks waiting on QoS 0 messages immediately
+            notifyWaitingTask(waitingTask, true);
+            return false;
+        }
+
+        // Record pending task
+        Lock lock(mutex);
+        messages[messageId] = waitingTask;
+        return true;
+    }
+
+    bool handlePublished(int messageId, bool success) {
+        if (messageId == 0) {
+            return false;
+        }
+
+        Lock lock(mutex);
+        auto it = messages.find(messageId);
+        if (it != messages.end()) {
+            notifyWaitingTask(it->second, success);
+            messages.erase(it);
+            return true;
+        }
+        return false;
+    }
+
+    bool cancelWaitingOn(TaskHandle_t waitingTask) {
+        if (waitingTask == nullptr) {
+            return false;
+        }
+
+        Lock lock(mutex);
+        bool removed = false;
+        for (auto it = messages.begin(); it != messages.end();) {
+            if (it->second == waitingTask) {
+                it = messages.erase(it);
+                removed = true;
+            } else {
+                ++it;
+            }
+        }
+        return removed;
+    }
+
+    void clear() {
+        Lock lock(mutex);
+        for (auto& [messageId, waitingTask] : messages) {
+            notifyWaitingTask(waitingTask, false);
+        }
+        messages.clear();
+    }
+
+    static void notifyWaitingTask(TaskHandle_t task, bool success) {
+        if (task != nullptr) {
+            auto status = success ? PublishStatus::Success : PublishStatus::Failed;
+            xTaskNotify(task, static_cast<int>(status), eSetValueWithOverwrite);
+        }
+    }
+
+private:
+    Mutex mutex;
+    std::unordered_map<int, TaskHandle_t> messages;
+};
+
+}    // namespace farmhub::kernel::mqtt

--- a/data-templates/device-config-wokwi.json
+++ b/data-templates/device-config-wokwi.json
@@ -1,6 +1,5 @@
 {
-  "id": "wokwi",
-  "instance": "wokwi",
+  "instance": "test-wokwi",
   "location": "bumblebee",
   "peripherals": [
     {


### PR DESCRIPTION
Fixes #366.

It frequently happens that clients send multiple `PUBLISH` packets, causing the server to kill the connection with `protocol error`. The time between these packages is about 1 second, which is the default resend timeout we've been using so far. Increasing this timeout to 5 seconds should get rid of this problem.