### PR TITLE
Lower boot threshold voltages for MK6 and MK7

### DIFF
--- a/components/devices/devices/UglyDucklingMk6.hpp
+++ b/components/devices/devices/UglyDucklingMk6.hpp
@@ -102,7 +102,7 @@ public:
             1.2424,
             BatteryParameters {
                 .maximumVoltage = 4.1,
-                .bootThreshold = 3.7,
+                .bootThreshold = 3.6,
                 .shutdownThreshold = 3.4,
             });
     }

--- a/components/devices/devices/UglyDucklingMk7.hpp
+++ b/components/devices/devices/UglyDucklingMk7.hpp
@@ -97,7 +97,7 @@ public:
             pins::SCL,
             BatteryParameters {
                 .maximumVoltage = 4.1,
-                .bootThreshold = 3.7,
+                .bootThreshold = 3.6,
                 .shutdownThreshold = 3.0,
             });
     }


### PR DESCRIPTION
* MK6: 3.7 -> 3.6 V
* MK7: 3.7 -> 3.6 V