### PR TITLE
Increase battery manager task's stack size

### DIFF
--- a/components/devices/Device.hpp
+++ b/components/devices/Device.hpp
@@ -127,8 +127,8 @@ std::shared_ptr<BatteryDriver> initBattery(std::shared_ptr<I2CManager> i2c) {
         // This is to prevent the device from booting and immediately shutting down
         // due to the high current draw of the boot process.
         auto voltage = battery->getVoltage();
-        if (voltage != 0.0 && voltage < battery->parameters.bootThreshold) {
-            ESP_LOGW("battery", "Battery voltage too low (%.2f V < %.2f), entering deep sleep\n",
+        if (voltage != 0 && voltage < battery->parameters.bootThreshold) {
+            ESP_LOGW("battery", "Battery voltage too low (%d mV < %d mV), entering deep sleep\n",
                 voltage, battery->parameters.bootThreshold);
             enterLowPowerDeepSleep();
         }
@@ -274,7 +274,7 @@ void initTelemetryPublishTask(
             telemetry["timestamp"] = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 
             if (batteryManager != nullptr) {
-                telemetry["battery"]["voltage"] = batteryManager->getVoltage();
+                telemetry["battery"]["voltage"] = static_cast<double>(batteryManager->getVoltage()) / 1000.0; // Convert to volts
             }
 
             auto wifiData = telemetry["wifi"].to<JsonObject>();

--- a/components/devices/devices/UglyDucklingMk6.hpp
+++ b/components/devices/devices/UglyDucklingMk6.hpp
@@ -101,9 +101,9 @@ public:
             pins::BATTERY,
             1.2424,
             BatteryParameters {
-                .maximumVoltage = 4.1,
-                .bootThreshold = 3.6,
-                .shutdownThreshold = 3.4,
+                .maximumVoltage = 4100,
+                .bootThreshold = 3600,
+                .shutdownThreshold = 3400,
             });
     }
 

--- a/components/devices/devices/UglyDucklingMk7.hpp
+++ b/components/devices/devices/UglyDucklingMk7.hpp
@@ -96,9 +96,9 @@ public:
             pins::SDA,
             pins::SCL,
             BatteryParameters {
-                .maximumVoltage = 4.1,
-                .bootThreshold = 3.6,
-                .shutdownThreshold = 3.0,
+                .maximumVoltage = 4100,
+                .bootThreshold = 3600,
+                .shutdownThreshold = 3000,
             });
     }
 

--- a/components/kernel/BatteryManager.hpp
+++ b/components/kernel/BatteryManager.hpp
@@ -35,7 +35,7 @@ public:
         std::shared_ptr<ShutdownManager> shutdownManager)
         : battery(std::move(battery))
         , shutdownManager(std::move(shutdownManager)) {
-        Task::loop("battery", 2560, [this](Task& task) {
+        Task::loop("battery", 3072, [this](Task& task) {
             checkBatteryVoltage(task);
         });
     }

--- a/components/kernel/BatteryManager.hpp
+++ b/components/kernel/BatteryManager.hpp
@@ -40,7 +40,13 @@ public:
         });
     }
 
-    double getVoltage() {
+    /**
+     * @brief Get the Voltage object
+     *
+     * @return int Battery voltage in millivolts, -1 if voltage cannot be determined,
+     * or 0 if device has no battery.
+     */
+    int getVoltage() {
         return batteryVoltage.getAverage();
     }
 
@@ -51,8 +57,8 @@ private:
         batteryVoltage.record(currentVoltage);
         auto voltage = batteryVoltage.getAverage();
 
-        if (voltage != 0.0 && voltage < battery->parameters.shutdownThreshold) {
-            LOGI("Battery voltage low (%.2f V < %.2f), starting shutdown process, will go to deep sleep in %lld seconds",
+        if (voltage != 0 && voltage < battery->parameters.shutdownThreshold) {
+            LOGI("Battery voltage low (%d mV < %d mV), starting shutdown process, will go to deep sleep in %lld seconds",
                 voltage, battery->parameters.shutdownThreshold, duration_cast<seconds>(LOW_BATTERY_SHUTDOWN_TIMEOUT).count());
 
             // TODO Publish all MQTT messages, then shut down WiFi, and _then_ start shutting down peripherals
@@ -67,7 +73,7 @@ private:
     const std::shared_ptr<BatteryDriver> battery;
     const std::shared_ptr<ShutdownManager> shutdownManager;
 
-    MovingAverage<double> batteryVoltage { 5 };
+    MovingAverage<int> batteryVoltage { 5 };
 
     /**
      * @brief How often we check the battery voltage while in operation.

--- a/components/kernel/MovingAverage.hpp
+++ b/components/kernel/MovingAverage.hpp
@@ -4,17 +4,18 @@
 
 namespace farmhub::kernel {
 
-template <std::floating_point T>
+template <typename M, typename T = M>
+requires std::is_arithmetic_v<M> && std::is_arithmetic_v<T>
 class MovingAverage {
 public:
     explicit MovingAverage(std::size_t maxMeasurements)
         : maxMeasurements(maxMeasurements)
-        , measurements(maxMeasurements, T(0))
+        , measurements(maxMeasurements, M(0))
         , sum(0)
         , average(0) {
     }
 
-    void record(T measurement) {
+    void record(M measurement) {
         if (count == maxMeasurements) {
             sum -= measurements[currentIndex];
         } else {
@@ -34,7 +35,7 @@ public:
 
 private:
     const std::size_t maxMeasurements;
-    std::vector<T> measurements;
+    std::vector<M> measurements;
     std::size_t currentIndex{0};
     std::size_t count{0};
     T sum;

--- a/components/kernel/drivers/BatteryDriver.hpp
+++ b/components/kernel/drivers/BatteryDriver.hpp
@@ -12,16 +12,20 @@ using farmhub::kernel::PinPtr;
 namespace farmhub::kernel::drivers {
 
 struct BatteryParameters {
-    const double maximumVoltage;
     /**
-     * @brief Do not boot if battery is below this threshold.
+     * @brief Maximum voltage of the battery in millivolts.
+     *
      */
-    const double bootThreshold;
+    const int maximumVoltage;
+    /**
+     * @brief Do not boot if battery is below this threshold in millivolts.
+     */
+    const int bootThreshold;
 
     /**
-     * @brief Shutdown if battery drops below this threshold.
+     * @brief Shutdown if battery drops below this threshold in millivolts.
      */
-    const double shutdownThreshold;
+    const int shutdownThreshold;
 };
 
 class BatteryDriver {
@@ -32,7 +36,12 @@ public:
 
     virtual ~BatteryDriver() = default;
 
-    virtual double getVoltage() = 0;
+    /**
+     * @brief Get the battery voltage.
+     *
+     * @return Battery voltage in millivolts, or -1 if the read failed.
+     */
+    virtual int getVoltage() = 0;
 
     const BatteryParameters parameters;
 };
@@ -48,16 +57,16 @@ public:
             analogPin.getName().c_str());
     }
 
-    double getVoltage() override {
+    int getVoltage() override {
         for (int trial = 0; trial < 5; trial++) {
             auto batteryLevel = analogPin.analogRead();
             if (!batteryLevel.has_value()) {
                 LOGE("Failed to read battery level");
                 continue;
             }
-            return batteryLevel.value() * 3.3 / 4096 * voltageDividerRatio;
+            return static_cast<int>(batteryLevel.value() * 3.3 / 4096 * voltageDividerRatio * 1000);
         }
-        return std::numeric_limits<double>::quiet_NaN();
+        return -1;
     }
 
 private:

--- a/components/kernel/drivers/Bq27220Driver.hpp
+++ b/components/kernel/drivers/Bq27220Driver.hpp
@@ -39,9 +39,9 @@ public:
             address, readControlWord(0x0002), readControlWord(0x0003));
     }
 
-    double getVoltage() override {
+    int getVoltage() override {
         // LOGV("Capacityt: %d/%d", readRegWord(0x10), readRegWord(0x12));
-        return device->readRegWord(0x08) / 1000.0;
+        return device->readRegWord(0x08);
     }
 
     double getCurrent() {

--- a/components/peripherals/peripherals/analog_meter/AnalogMeter.hpp
+++ b/components/peripherals/peripherals/analog_meter/AnalogMeter.hpp
@@ -36,7 +36,7 @@ public:
         LOGI("Initializing analog meter on pin %s",
             pin->getName().c_str());
 
-        Task::loop(name, 3172, [this, measurementFrequency, offset, multiplier](Task& task) {
+        Task::loop(name, 3072, [this, measurementFrequency, offset, multiplier](Task& task) {
             auto measurement = this->pin.analogRead();
             if (measurement.has_value()) {
                 double value = offset + measurement.value() * multiplier;

--- a/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
@@ -62,7 +62,7 @@ public:
         }
 
         auto measurementFrequency = settings->measurementFrequency.get();
-        Task::loop(name, 3172, [this, measurementFrequency](Task& task) {
+        Task::loop(name, 3072, [this, measurementFrequency](Task& task) {
             uint16_t lastVoltage = 0;
             for (auto& pin : pins) {
                 uint32_t count = pin.counter->reset();

--- a/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
@@ -45,7 +45,7 @@ public:
         lastSeenFlow = now;
         lastPublished = now;
 
-        Task::loop(name, 3172, [this, measurementFrequency](Task& task) {
+        Task::loop(name, 3072, [this, measurementFrequency](Task& task) {
             auto now = boot_clock::now();
             milliseconds elapsed = duration_cast<milliseconds>(now - lastMeasurement);
             if (elapsed.count() > 0) {


### PR DESCRIPTION
This is because `mains` kept crashing due to a stack overflow in `battery`.

Also reduce other task sizes that were set at 3172 instead of 3072 (3 KiB).