### PR TITLE
Make override configuration part of valve configuration

### DIFF
--- a/components/peripherals/peripherals/flow_control/FlowControl.hpp
+++ b/components/peripherals/peripherals/flow_control/FlowControl.hpp
@@ -36,7 +36,7 @@ public:
     }
 
     void configure(const std::shared_ptr<FlowControlConfig> config) override {
-        valve->setSchedules(config->schedule.get());
+        valve->configure(config->schedule.get(), config->overrideState.get(), config->overrideUntil.get());
     }
 
     void shutdown(const ShutdownParameters /*parameters*/) override {

--- a/components/peripherals/peripherals/valve/ValveConfig.hpp
+++ b/components/peripherals/peripherals/valve/ValveConfig.hpp
@@ -26,6 +26,8 @@ class ValveConfig
     : public ConfigurationSection {
 public:
     ArrayProperty<ValveSchedule> schedule { this, "schedule" };
+    Property<ValveState> overrideState { this, "overrideState", ValveState::NONE };
+    Property<time_point<system_clock>> overrideUntil { this, "overrideUntil" };
 };
 
 class ValveSettings

--- a/components/peripherals/peripherals/valve/ValvePeripheral.hpp
+++ b/components/peripherals/peripherals/valve/ValvePeripheral.hpp
@@ -33,7 +33,7 @@ public:
     }
 
     void configure(const std::shared_ptr<ValveConfig> config) override {
-        valve->setSchedules(config->schedule.get());
+        valve->configure(config->schedule.get(), config->overrideState.get(), config->overrideUntil.get());
     }
 
     void shutdown(const ShutdownParameters /*parameters*/) override {

--- a/components/peripherals/peripherals/valve/ValveSchedule.hpp
+++ b/components/peripherals/peripherals/valve/ValveSchedule.hpp
@@ -43,36 +43,48 @@ private:
 namespace ArduinoJson {
 
 using farmhub::peripherals::valve::ValveSchedule;
+
+template <>
+struct Converter<system_clock::time_point> {
+    static void toJson(system_clock::time_point src, JsonVariant dst) {
+        time_t t = system_clock::to_time_t(src);
+        tm tm {};
+        localtime_r(&t, &tm);
+        char buf[64];
+        (void) strftime(buf, sizeof(buf), "%FT%TZ", &tm);
+        dst.set(buf);
+    }
+
+    static system_clock::time_point fromJson(JsonVariantConst src) {
+        tm tm {};
+        strptime(src.as<const char*>(), "%FT%TZ", &tm);
+        tm.tm_isdst = 0;
+        return system_clock::from_time_t(mktime(&tm));
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<const char*>();
+    }
+};
+
 template <>
 struct Converter<ValveSchedule> {
     static void toJson(const ValveSchedule& src, JsonVariant dst) {
         JsonObject obj = dst.to<JsonObject>();
-        auto startLocalTime = src.getStart();
-        auto startTime = system_clock::to_time_t(startLocalTime);
-        tm startTm {};
-        localtime_r(&startTime, &startTm);
-        char buf[64];
-        (void) strftime(buf, sizeof(buf), "%FT%TZ", &startTm);
-        obj["start"] = buf;
+        obj["start"] = src.getStart();
         obj["period"] = src.getPeriod().count();
         obj["duration"] = src.getDuration().count();
     }
 
     static ValveSchedule fromJson(JsonVariantConst src) {
-        tm startTm {};
-        strptime(src["start"].as<const char*>(), "%FT%TZ", &startTm);
-        // Must manually set this, otherwise mktime cannot parse the time properly
-        // See notes at https://en.cppreference.com/w/cpp/chrono/c/mktime
-        startTm.tm_isdst = 0;
-        auto startTime = mktime(&startTm);
-        auto startLocalTime = system_clock::from_time_t(startTime);
-        seconds period = seconds(src["period"].as<int64_t>());
-        seconds duration = seconds(src["duration"].as<int64_t>());
-        return { startLocalTime, period, duration };
+        auto start = src["start"].as<time_point<system_clock>>();
+        auto period = seconds(src["period"].as<int64_t>());
+        auto duration = seconds(src["duration"].as<int64_t>());
+        return { start, period, duration };
     }
 
     static bool checkJson(JsonVariantConst src) {
-        return src["start"].is<const char*>()
+        return src["start"].is<time_point<system_clock>>()
             && src["period"].is<int64_t>()
             && src["duration"].is<int64_t>();
     }


### PR DESCRIPTION
This makes overrides permanent across restarts. So if the user has set an override, and the device reboots for whatever reason, the override stays in effect.