### PR TITLE
Do not report overrideEnd as part of telemetry

### DIFF
--- a/components/peripherals/peripherals/chicken_door/ChickenDoor.hpp
+++ b/components/peripherals/peripherals/chicken_door/ChickenDoor.hpp
@@ -189,12 +189,6 @@ public:
         telemetry["targetState"] = lastTargetState;
         telemetry["operationState"] = operationState;
         if (overrideState != DoorState::NONE) {
-            time_t rawtime = system_clock::to_time_t(overrideUntil);
-            std::tm timeinfo {};
-            gmtime_r(&rawtime, &timeinfo);
-            char buffer[80];
-            (void) strftime(buffer, 80, "%FT%TZ", &timeinfo);
-            telemetry["overrideEnd"] = std::string(buffer);
             telemetry["overrideState"] = overrideState;
         }
     }

--- a/components/peripherals/peripherals/valve/Valve.hpp
+++ b/components/peripherals/peripherals/valve/Valve.hpp
@@ -321,15 +321,9 @@ public:
 
     void populateTelemetry(JsonObject& telemetry) {
         telemetry["state"] = this->state;
-        auto overrideUntil = this->overrideUntil.load();
-        if (overrideUntil != time_point<system_clock>()) {
-            time_t rawtime = system_clock::to_time_t(overrideUntil);
-            std::tm timeinfo {};
-            gmtime_r(&rawtime, &timeinfo);
-            char buffer[80];
-            (void) strftime(buffer, 80, "%FT%TZ", &timeinfo);
-            telemetry["overrideEnd"] = std::string(buffer);
-            telemetry["overrideState"] = this->overrideState.load();
+        auto overrideState = this->overrideState.load();
+        if (overrideState != ValveState::NONE) {
+            telemetry["overrideState"] = overrideState;
         }
     }
 


### PR DESCRIPTION
We don't need it as it is stored as part of the peripheral config.