### PR TITLE
Fix polarity of MK7 motor output

### DIFF
--- a/components/devices/devices/UglyDucklingMk6.hpp
+++ b/components/devices/devices/UglyDucklingMk6.hpp
@@ -116,7 +116,8 @@ protected:
             pins::BIN1,
             pins::BIN2,
             pins::NFault,
-            settings->motorNSleepPin.get());
+            settings->motorNSleepPin.get(),
+            true);
 
         std::map<std::string, std::shared_ptr<PwmMotorDriver>> motors = { { "a", motorDriver->getMotorA() }, { "b", motorDriver->getMotorB() } };
 


### PR DESCRIPTION
Between MK6 and MK7 we've reversed the polarity of the RJ45 outputs (OUT1 and OUT2). So from this on, we are treating the MK7 configuration as the right one, and MK6 is now configured as reversed. This is a good idea because MK8 will have the same configuration, as well as future generations.