### PR TITLE
Update telemetry every 5 minutes by default

### DIFF
--- a/components/devices/devices/DeviceSettings.hpp
+++ b/components/devices/devices/DeviceSettings.hpp
@@ -30,7 +30,7 @@ public:
 
     Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
 
-    Property<seconds> publishInterval { this, "publishInterval", 1min };
+    Property<seconds> publishInterval { this, "publishInterval", 5min };
     Property<Level> publishLogs { this, "publishLogs",
 #ifdef FARMHUB_DEBUG
         Level::Verbose


### PR DESCRIPTION
The goal here is to reduce battery usage by contacting the server less often by default. WiFi transmit is typically among the most expensive operation on ugly duckling devices, so doing them less frequently makes sense. We can also conserve storage space on the server if we have less data to track.

Devices are still allowed to send telemetry updates when some important change happens out-of-band, i.e. when a valve opens/closes.

It is also possible to configure a specific device to send updates every minute or even more frequent, this is just changing the default.

Also note that we had 1 minute telemetry updates since the beginning, because at some point the devices could only receive commands / configuration updates when they were also transmitting. This is not the case for a while now, and devices should respond to commands in a few seconds regardless of telemetry schedule.