### PR TITLE
Enable glitch filter for flow meter

### DIFF
--- a/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
@@ -47,7 +47,10 @@ public:
         LOGI("Initializing electric fence with pins %s", pinsDescription.c_str());
 
         for (const auto& pinConfig : settings->pins.get()) {
-            auto unit = pulseCounterManager->create(pinConfig.pin);
+            auto unit = pulseCounterManager->create({
+                .pin = pinConfig.pin,
+                .glitchFilter = false,
+             });
             pins.emplace_back(pinConfig.voltage, unit);
         }
 

--- a/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
@@ -45,7 +45,10 @@ public:
         LOGI("Initializing flow meter on pin %s with Q = %.2f",
             pin->getName().c_str(), qFactor);
 
-        counter = pulseCounterManager->create(pin);
+        counter = pulseCounterManager->create({
+            .pin = pin,
+            .glitchFilter = true,
+        });
 
         auto now = boot_clock::now();
         lastMeasurement = now;

--- a/data-templates/chicken-door-mk6.json
+++ b/data-templates/chicken-door-mk6.json
@@ -30,5 +30,5 @@
       }
     }
   ],
-  "motorNSleepPin": "C4"
+  "motorNSleepPin": "LOADEN"
 }


### PR DESCRIPTION
Sometimes the magnet of a flow meter's Hall sensor stops right in front of the sensor, and as it moves back-and-forth it can generate lots of noise. Let's reduce that by enabling the glitch filter built into the ESP32 MCU itself.