### PR TITLE
Set watchdog timer to 15 minutes, and make it configurable

### DIFF
--- a/components/devices/Device.hpp
+++ b/components/devices/Device.hpp
@@ -153,8 +153,8 @@ void initNvsFlash() {
     ESP_ERROR_CHECK(err);
 }
 
-std::shared_ptr<Watchdog> initWatchdog() {
-    return std::make_shared<Watchdog>("watchdog", 15min, true, [](WatchdogState state) {
+std::shared_ptr<Watchdog> initWatchdog(seconds timeout) {
+    return std::make_shared<Watchdog>("watchdog", timeout, true, [](WatchdogState state) {
         if (state == WatchdogState::TimedOut) {
             LOGE("Watchdog timed out");
             esp_system_abort("Watchdog timed out");
@@ -342,13 +342,13 @@ static void startDevice() {
     ESP_ERROR_CHECK(heap_trace_init_standalone(trace_record, NUM_RECORDS));
 #endif
 
-    auto watchdog = initWatchdog();
-
     auto deviceDefinition = std::make_shared<TDeviceDefinition>();
 
     auto fs = std::make_shared<FileSystem>();
 
     auto settings = loadConfig<TDeviceSettings>(fs, "/device-config.json");
+
+    auto watchdog = initWatchdog(settings->watchdogTimeout.get());
 
     auto powerManager = std::make_shared<PowerManager>(settings->sleepWhenIdle.get());
 

--- a/components/devices/Device.hpp
+++ b/components/devices/Device.hpp
@@ -154,7 +154,7 @@ void initNvsFlash() {
 }
 
 std::shared_ptr<Watchdog> initWatchdog() {
-    return std::make_shared<Watchdog>("watchdog", 5min, true, [](WatchdogState state) {
+    return std::make_shared<Watchdog>("watchdog", 15min, true, [](WatchdogState state) {
         if (state == WatchdogState::TimedOut) {
             LOGE("Watchdog timed out");
             esp_system_abort("Watchdog timed out");

--- a/components/devices/devices/DeviceSettings.hpp
+++ b/components/devices/devices/DeviceSettings.hpp
@@ -12,8 +12,7 @@ using namespace farmhub::kernel::drivers;
 
 namespace farmhub::devices {
 
-class DeviceSettings : public ConfigurationSection {
-public:
+struct DeviceSettings : ConfigurationSection {
     explicit DeviceSettings(const std::string& defaultModel)
         : model(this, "model", defaultModel)
         , instance(this, "instance", getMacAddress()) {
@@ -30,6 +29,9 @@ public:
 
     Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
 
+    /**
+     * @brief How often to publish telemetry.
+     */
     Property<seconds> publishInterval { this, "publishInterval", 5min };
     Property<Level> publishLogs { this, "publishLogs",
 #ifdef FARMHUB_DEBUG
@@ -38,6 +40,11 @@ public:
         Level::Info
 #endif
     };
+
+    /**
+     * @brief How long without successfully published telemetry before the watchdog times out and reboots the device.
+     */
+    Property<seconds> watchdogTimeout { this, "watchdogTimeout", 15min };
 
     std::string getHostname() const {
         std::string hostname = instance.get();


### PR DESCRIPTION
We are now publishing telemetry every five minutes, so a watchdog rebooting the device every five minutes unless a telemetry update goes out is not very useful. Let's do 15 minutes instead.