### PR TITLE
Disable glitch filter on flow-meter to enable sleep again

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,12 +23,14 @@ Checks:
   - -cppcoreguidelines-special-member-functions
   - google-*
   - -google-build-using-namespace
+  - -google-explicit-constructor
   - -google-global-names-in-headers
   - -google-objc-*
   - -google-readability-todo
   - hicpp-*
   - -hicpp-avoid-c-arrays
   - -hicpp-avoid-goto
+  - -hicpp-explicit-conversions
   - -hicpp-member-init
   - -hicpp-no-array-decay
   - -hicpp-signed-bitwise

--- a/components/devices/devices/DeviceSettings.hpp
+++ b/components/devices/devices/DeviceSettings.hpp
@@ -13,7 +13,7 @@ using namespace farmhub::kernel::drivers;
 namespace farmhub::devices {
 
 struct DeviceSettings : ConfigurationSection {
-    explicit DeviceSettings(const std::string& defaultModel)
+    DeviceSettings(const std::string& defaultModel)
         : model(this, "model", defaultModel)
         , instance(this, "instance", getMacAddress()) {
     }

--- a/components/devices/devices/UglyDucklingMk5.hpp
+++ b/components/devices/devices/UglyDucklingMk5.hpp
@@ -70,7 +70,7 @@ static const InternalPinPtr TXD0 = InternalPin::registerPin("TXD0", GPIO_NUM_43)
 
 class UglyDucklingMk5 : public DeviceDefinition<Mk5Settings> {
 public:
-    explicit UglyDucklingMk5()
+    UglyDucklingMk5()
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 

--- a/components/devices/devices/UglyDucklingMk6.hpp
+++ b/components/devices/devices/UglyDucklingMk6.hpp
@@ -86,7 +86,7 @@ public:
 
 class UglyDucklingMk6 : public DeviceDefinition<Mk6Settings> {
 public:
-    explicit UglyDucklingMk6()
+    UglyDucklingMk6()
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
         // Switch off strapping pin
         // TODO(lptr): Add a LED driver instead

--- a/components/devices/devices/UglyDucklingMk7.hpp
+++ b/components/devices/devices/UglyDucklingMk7.hpp
@@ -78,7 +78,7 @@ public:
 
 class UglyDucklingMk7 : public DeviceDefinition<Mk7Settings> {
 public:
-    explicit UglyDucklingMk7()
+    UglyDucklingMk7()
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
         // Switch off strapping pin
         // TODO: Add a LED driver instead

--- a/components/devices/devices/UglyDucklingMk8.hpp
+++ b/components/devices/devices/UglyDucklingMk8.hpp
@@ -104,7 +104,7 @@ public:
 
 class UglyDucklingMk8 : public DeviceDefinition<Mk8Settings> {
 public:
-    explicit UglyDucklingMk8()
+    UglyDucklingMk8()
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
         // Switch off strapping pin
         // TODO: Add a LED driver instead

--- a/components/devices/devices/UglyDucklingMkX.hpp
+++ b/components/devices/devices/UglyDucklingMkX.hpp
@@ -27,7 +27,7 @@ public:
 
 class UglyDucklingMkX : public DeviceDefinition<MkXSettings> {
 public:
-    explicit UglyDucklingMkX()
+    UglyDucklingMkX()
         : DeviceDefinition(pins::STATUS, pins::BOOT) {
     }
 

--- a/components/functions/functions/chicken_door/ChickenDoor.hpp
+++ b/components/functions/functions/chicken_door/ChickenDoor.hpp
@@ -50,7 +50,7 @@ struct LightSensorSchedule {
 };
 
 struct LightSensorScheduler : IScheduler {
-    explicit LightSensorScheduler(const std::shared_ptr<ILightSensor>& lightSensor)
+    LightSensorScheduler(const std::shared_ptr<ILightSensor>& lightSensor)
         : lightSensor(lightSensor) {
     }
 
@@ -159,7 +159,7 @@ struct ChickenDoorSettings : ConfigurationSection {
 };
 
 struct NoOpLightSensor : virtual ILightSensor, Named {
-    explicit NoOpLightSensor(const std::string& name)
+    NoOpLightSensor(const std::string& name)
         : Named(name) {
     }
 

--- a/components/functions/functions/plot_controller/PlotController.hpp
+++ b/components/functions/functions/plot_controller/PlotController.hpp
@@ -145,7 +145,7 @@ struct PlotControllerSettings : ConfigurationSection {
 };
 
 struct NoOpFlowMeter : virtual IFlowMeter, Named {
-    explicit NoOpFlowMeter(const std::string& name)
+    NoOpFlowMeter(const std::string& name)
         : Named(name) {
     }
 
@@ -159,7 +159,7 @@ struct NoOpFlowMeter : virtual IFlowMeter, Named {
 };
 
 struct NoOpSoilMoistureSensor : virtual ISoilMoistureSensor, Named {
-    explicit NoOpSoilMoistureSensor(const std::string& name)
+    NoOpSoilMoistureSensor(const std::string& name)
         : Named(name) {
     }
 

--- a/components/kernel/Concurrent.hpp
+++ b/components/kernel/Concurrent.hpp
@@ -47,7 +47,7 @@ private:
 template <typename TMessage>
 class Queue : public BaseQueue {
 public:
-    explicit Queue(const std::string& name, size_t capacity = 16)
+    Queue(const std::string& name, size_t capacity = 16)
         : BaseQueue(name, sizeof(TMessage*), capacity) {
     }
 
@@ -163,7 +163,7 @@ public:
 template <typename TMessage>
 class CopyQueue : public BaseQueue {
 public:
-    explicit CopyQueue(const std::string& name, size_t capacity = 16)
+    CopyQueue(const std::string& name, size_t capacity = 16)
         : BaseQueue(name, sizeof(TMessage), capacity) {
     }
 
@@ -290,7 +290,7 @@ private:
 
 class Lock {
 public:
-    explicit Lock(MutexBase& mutex)
+    Lock(MutexBase& mutex)
         : mutex(mutex) {
         mutex.lock();
     }

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -21,7 +21,7 @@ namespace farmhub::kernel {
 class ConfigurationException
     : public std::exception {
 public:
-    explicit ConfigurationException(const std::string& message)
+    ConfigurationException(const std::string& message)
         : message("ConfigurationException: " + message) {
     }
 
@@ -36,7 +36,7 @@ class JsonAsString {
 public:
     JsonAsString() = default;
 
-    explicit JsonAsString(const std::string& value)
+    JsonAsString(const std::string& value)
         : value(value) {
     }
 
@@ -410,7 +410,7 @@ struct Converter<JsonAsString> {
     static JsonAsString fromJson(JsonVariantConst src) {
         std::string value;
         serializeJson(src, value);
-        return JsonAsString(value);
+        return { value };
     }
 
     static bool checkJson(JsonVariantConst /* src */) {

--- a/components/kernel/EspException.hpp
+++ b/components/kernel/EspException.hpp
@@ -8,7 +8,7 @@ namespace farmhub::kernel {
 class EspException
     : public std::runtime_error {
 public:
-    explicit EspException(esp_err_t err)
+    EspException(esp_err_t err)
         : std::runtime_error(esp_err_to_name(err)) {
     }
 };

--- a/components/kernel/HttpUpdate.hpp
+++ b/components/kernel/HttpUpdate.hpp
@@ -70,7 +70,7 @@ public:
     static constexpr const char* UPDATE_FILE = "/update.json";
 
 private:
-    explicit HttpUpdater(std::shared_ptr<Watchdog> watchdog)
+    HttpUpdater(std::shared_ptr<Watchdog> watchdog)
         : watchdog(std::move(watchdog)) {
     }
 

--- a/components/kernel/Manager.hpp
+++ b/components/kernel/Manager.hpp
@@ -19,7 +19,7 @@ struct ShutdownParameters {
     // Placeholder for future parameters
 };
 
-// Explicit shutdown capability for implementations that support graceful shutdown
+// shutdown capability for implementations that support graceful shutdown
 class HasShutdown {
 public:
     virtual ~HasShutdown() = default;
@@ -88,7 +88,7 @@ struct Factory {
 template <typename FactoryT>
 class Manager {
 public:
-    explicit Manager(std::string managed)
+    Manager(std::string managed)
         : managed(std::move(managed)) {
     }
 
@@ -172,7 +172,7 @@ template <typename FactoryT>
 class SettingsBasedManager
     : public Manager<FactoryT> {
 public:
-    explicit SettingsBasedManager(std::string managed)
+    SettingsBasedManager(std::string managed)
         : Manager<FactoryT>(std::move(managed)) {
     }
 

--- a/components/kernel/MovingAverage.hpp
+++ b/components/kernel/MovingAverage.hpp
@@ -8,7 +8,7 @@ template <typename M, typename T = M>
 requires std::is_arithmetic_v<M> && std::is_arithmetic_v<T>
 class MovingAverage {
 public:
-    explicit MovingAverage(std::size_t maxMeasurements)
+    MovingAverage(std::size_t maxMeasurements)
         : maxMeasurements(maxMeasurements)
         , measurements(maxMeasurements, M(0))
         , sum(0)

--- a/components/kernel/Named.hpp
+++ b/components/kernel/Named.hpp
@@ -4,7 +4,7 @@ namespace farmhub::kernel {
 
 class Named {
 protected:
-    explicit Named(const std::string& name)
+    Named(const std::string& name)
         : name(name) {
     }
 

--- a/components/kernel/NvsStore.hpp
+++ b/components/kernel/NvsStore.hpp
@@ -17,7 +17,7 @@ LOGGING_TAG(NVS, "nvs")
  */
 class NvsStore {
 public:
-    explicit NvsStore(const std::string& name)
+    NvsStore(const std::string& name)
         : name(name) {
     }
 

--- a/components/kernel/Pin.hpp
+++ b/components/kernel/Pin.hpp
@@ -63,7 +63,7 @@ public:
     virtual ~Pin() = default;
 
 protected:
-    explicit Pin(const std::string& name)
+    Pin(const std::string& name)
         : name(name) {
     }
 
@@ -202,7 +202,7 @@ class AnalogPin {
 public:
     static constexpr double MAX_ANALOG_VALUE = 4096.0;
 
-    explicit AnalogPin(const InternalPinPtr& pin)
+    AnalogPin(const InternalPinPtr& pin)
         : pin(pin) {
         adc_unit_t unit;
         ESP_ERROR_THROW(adc_oneshot_io_to_channel(pin->getGpio(), &unit, &channel));

--- a/components/kernel/PowerManager.hpp
+++ b/components/kernel/PowerManager.hpp
@@ -44,7 +44,7 @@ private:
 
 class PowerManagementLockGuard {
 public:
-    explicit PowerManagementLockGuard(PowerManagementLock& lock)
+    PowerManagementLockGuard(PowerManagementLock& lock)
         : lock(lock) {
         ESP_ERROR_THROW(esp_pm_lock_acquire(lock.lock));
     }
@@ -65,7 +65,7 @@ private:
 
 class PowerManager final {
 public:
-    explicit PowerManager(bool requestedSleepWhenIdle)
+    PowerManager(bool requestedSleepWhenIdle)
         : sleepWhenIdle(shouldSleepWhenIdle(requestedSleepWhenIdle)) {
 
         LOGTV(PM, "Configuring power management, CPU max/min at %d/%d MHz, light sleep is %s",

--- a/components/kernel/Task.hpp
+++ b/components/kernel/Task.hpp
@@ -22,7 +22,7 @@ using TaskFunction = std::function<void(Task&)>;
 
 class TaskHandle {
 public:
-    explicit TaskHandle(TaskHandle_t handle)
+    TaskHandle(TaskHandle_t handle)
         : handle(handle) {
     }
 

--- a/components/kernel/Telemetry.hpp
+++ b/components/kernel/Telemetry.hpp
@@ -45,7 +45,7 @@ private:
 
 class TelemetryPublisher {
 public:
-    explicit TelemetryPublisher(const std::shared_ptr<CopyQueue<bool>>& telemetryPublishQueue)
+    TelemetryPublisher(const std::shared_ptr<CopyQueue<bool>>& telemetryPublishQueue)
         : telemetryPublishQueue(telemetryPublishQueue) {}
 
     void requestTelemetryPublishing() {

--- a/components/kernel/drivers/BatteryDriver.hpp
+++ b/components/kernel/drivers/BatteryDriver.hpp
@@ -30,7 +30,7 @@ struct BatteryParameters {
 
 class BatteryDriver {
 public:
-    explicit BatteryDriver(const BatteryParameters& parameters)
+    BatteryDriver(const BatteryParameters& parameters)
         : parameters(parameters) {
     }
 

--- a/components/peripherals/peripherals/Peripheral.hpp
+++ b/components/peripherals/peripherals/Peripheral.hpp
@@ -35,7 +35,7 @@ class Peripheral
     : public virtual IPeripheral,
       public Named {
 public:
-    explicit Peripheral(const std::string& name)
+    Peripheral(const std::string& name)
         : Named(name) {
     }
 

--- a/components/peripherals/peripherals/PeripheralException.hpp
+++ b/components/peripherals/peripherals/PeripheralException.hpp
@@ -7,7 +7,7 @@ namespace farmhub::peripherals {
 class PeripheralCreationException
     : public std::runtime_error {
 public:
-    explicit PeripheralCreationException(const std::string& reason)
+    PeripheralCreationException(const std::string& reason)
         : std::runtime_error(reason) {
     }
 };

--- a/components/peripherals/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/components/peripherals/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -35,7 +35,7 @@ class Ds18B20SoilSensor final
     : public ITemperatureSensor,
       public Peripheral {
 public:
-    explicit Ds18B20SoilSensor(
+    Ds18B20SoilSensor(
         const std::string& name,
         const InternalPinPtr& pin,
         const std::string& address)

--- a/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
@@ -49,8 +49,7 @@ public:
         for (const auto& pinConfig : settings->pins.get()) {
             auto unit = pulseCounterManager->create({
                 .pin = pinConfig.pin,
-                .glitchFilter = false,
-             });
+            });
             pins.emplace_back(pinConfig.voltage, unit);
         }
 

--- a/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
@@ -47,7 +47,6 @@ public:
 
         counter = pulseCounterManager->create({
             .pin = pin,
-            .glitchFilter = true,
         });
 
         auto now = boot_clock::now();

--- a/components/peripherals/peripherals/valve/ValveControlStrategy.hpp
+++ b/components/peripherals/peripherals/valve/ValveControlStrategy.hpp
@@ -34,7 +34,7 @@ public:
 class MotorValveControlStrategy
     : public ValveControlStrategy {
 public:
-    explicit MotorValveControlStrategy(const std::shared_ptr<PwmMotorDriver>& controller)
+    MotorValveControlStrategy(const std::shared_ptr<PwmMotorDriver>& controller)
         : controller(controller) {
     }
 
@@ -163,7 +163,7 @@ private:
 class LatchingPinValveControlStrategy
     : public ValveControlStrategy {
 public:
-    explicit LatchingPinValveControlStrategy(const PinPtr& pin)
+    LatchingPinValveControlStrategy(const PinPtr& pin)
         : pin(pin) {
         pin->pinMode(Pin::Mode::Output);
     }

--- a/components/peripherals/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/peripherals/valve/ValveSettings.hpp
@@ -19,7 +19,7 @@ namespace farmhub::peripherals::valve {
 class ValveSettings
     : public ConfigurationSection {
 public:
-    explicit ValveSettings(ValveControlStrategyType defaultStrategy)
+    ValveSettings(ValveControlStrategyType defaultStrategy)
         : strategy(this, "strategy", defaultStrategy) {
     }
 

--- a/components/utils/utils/DebouncedMeasurement.hpp
+++ b/components/utils/utils/DebouncedMeasurement.hpp
@@ -21,7 +21,7 @@ struct DebouncedParams {
 template <typename T>
 class DebouncedMeasurement {
 public:
-    explicit DebouncedMeasurement(
+    DebouncedMeasurement(
         std::move_only_function<std::optional<T>(const DebouncedParams<T>)> measure,
         std::chrono::milliseconds interval = 1s,
         const T& defaultValue = {})

--- a/components/utils/utils/scheduling/CompositeScheduler.hpp
+++ b/components/utils/utils/scheduling/CompositeScheduler.hpp
@@ -9,7 +9,7 @@
 namespace farmhub::utils::scheduling {
 
 struct CompositeScheduler : IScheduler {
-    explicit CompositeScheduler(std::list<std::shared_ptr<IScheduler>> schedulers)
+    CompositeScheduler(std::list<std::shared_ptr<IScheduler>> schedulers)
         : schedulers(std::move(schedulers)) {
     }
 

--- a/components/utils/utils/scheduling/MoistureKalmanFilter.hpp
+++ b/components/utils/utils/scheduling/MoistureKalmanFilter.hpp
@@ -20,7 +20,7 @@ namespace farmhub::utils::scheduling {
  */
 class MoistureKalmanFilter {
 public:
-    explicit MoistureKalmanFilter(double initMoistReal = 0.0,
+    MoistureKalmanFilter(double initMoistReal = 0.0,
         double initBeta = 0.0,
         double tempRef = 20.0)
         : moistReal(initMoistReal)


### PR DESCRIPTION
The ESP-IDF glitch-filter disables sleep unfortunately.