### PR TITLE
Fix chicken-door ignoring bouncing switch

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks:
   - -readability-use-anyofallof
 
 CheckOptions:
-  readability-function-cognitive-complexity.Threshold: 300
+  readability-function-cognitive-complexity.Threshold: 500
   cppcoreguidelines-avoid-do-while.IgnoreMacros: true
   hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: true
 


### PR DESCRIPTION
If the switch bounced between triggering the interrupt and getting the interrupt processed, we could end up reading the wrong state. Instead, we now carry the state we've seen when we detected the state transition, fixing this problem for good.