### PR TITLE
Publish debug property via init

### DIFF
--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -533,6 +533,11 @@ static void startDevice() {
             auto device = json["settings"].to<JsonObject>();
             settings->store(device);
             json["version"] = farmhubVersion;
+#ifdef FARMHUB_DEBUG
+            json["debug"] = true;
+#else
+            json["debug"] = false;
+#endif
             json["reset"] = esp_reset_reason();
             json["wakeup"] = esp_sleep_get_wakeup_cause();
             json["bootCount"] = bootCount++;

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -527,15 +527,11 @@ static void startDevice() {
     mqttRoot->publish(
         "init",
         [settings, initState, peripheralsInitJson, functionsInitJson, powerManager](JsonObject& json) {
-            // TODO Remove redundant mentions of "ugly-duckling"
-            json["type"] = "ugly-duckling";
             json["model"] = settings->model.get();
             json["instance"] = settings->instance.get();
             json["mac"] = getMacAddress();
             auto device = json["settings"].to<JsonObject>();
             settings->store(device);
-            // TODO Remove redundant mentions of "ugly-duckling"
-            json["app"] = "ugly-duckling";
             json["version"] = farmhubVersion;
             json["reset"] = esp_reset_reason();
             json["wakeup"] = esp_sleep_get_wakeup_cause();


### PR DESCRIPTION
Also drops publishing `type` and `app` as they are not processed on the server side anymore.