### PR TITLE
Allow valve to be configured with a pin only

### DIFF
--- a/components/peripherals/src/peripherals/valve/ValveFactory.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveFactory.hpp
@@ -35,8 +35,7 @@ inline PeripheralFactory makeFactory(
         "valve",
         "valve",
         [motors](PeripheralInitParameters& params, const std::shared_ptr<ValveSettings>& settings) {
-            auto motor = findMotor(motors, settings->motor.get());
-            auto strategy = settings->createValveControlStrategy(motor);
+            auto strategy = settings->createValveControlStrategy(motors, settings->motor.get());
             auto valve = std::make_shared<Valve>(
                 params.name,
                 std::move(strategy));

--- a/components/peripherals/src/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveSettings.hpp
@@ -58,12 +58,13 @@ public:
      */
     Property<milliseconds> switchDuration { this, "switchDuration", 500ms };
 
-    std::unique_ptr<ValveControlStrategy> createValveControlStrategy(const std::shared_ptr<PwmMotorDriver>& motor) const {
+    std::unique_ptr<ValveControlStrategy> createValveControlStrategy(const std::map<std::string, std::shared_ptr<PwmMotorDriver>>& motors, const std::string& motorName) const {
         PinPtr pin = this->pin.get();
         if (pin != nullptr) {
             return std::make_unique<LatchingPinValveControlStrategy>(pin);
         }
 
+        auto motor = findMotor(motors, motorName);
         auto switchDuration = this->switchDuration.get();
         auto holdDuty = this->holdDuty.get() / 100.0;
 


### PR DESCRIPTION
This used to be an option, but somehow got removed.