### PR TITLE
Do not disable power management when running under Wokwi

### DIFF
--- a/components/kernel/src/PowerManager.hpp
+++ b/components/kernel/src/PowerManager.hpp
@@ -134,10 +134,6 @@ private:
 #if FARMHUB_DEBUG
             LOGTI(PM, "Light sleep is disabled in debug mode");
             return false;
-#elif WOKWI
-            // See https://github.com/wokwi/wokwi-features/issues/922
-            LOGTI(PM, "Light sleep is disabled when running under Wokwi");
-            return false;
 #elif not(CONFIG_PM_ENABLE)
             LOGTI(PM, "Power management is disabled because CONFIG_PM_ENABLE is not set");
             return false;


### PR DESCRIPTION
We don't need this anymore as https://github.com/wokwi/wokwi-features/issues/922 is now fixed.