### PR TITLE
Simplify ULP pulse-counting logic

### DIFF
--- a/components/kernel/src/PulseCounter.cpp
+++ b/components/kernel/src/PulseCounter.cpp
@@ -148,8 +148,8 @@ void PulseCounterManager::start() {
     ulp_riscv_timer_stop();
     ulp_riscv_reset();
     ESP_ERROR_THROW(ulp_riscv_load_binary(ulp_pulse_counter_bin_start, size));
-    // Restart the ULP every 1000 µs after each ulp_riscv_halt() call.
-    // Must be set before ulp_riscv_run(); matches ULP_TIMER_PERIOD_US in pulse_counter.c.
+    // The timer triggers the very first ULP start; after that the ULP runs
+    // continuously and never halts, so the period value doesn't matter much.
     ESP_ERROR_THROW(ulp_set_wakeup_period(0, 1000));
 #elif defined(CONFIG_ULP_COPROC_TYPE_LP_CORE)
     ESP_ERROR_THROW(ulp_lp_core_load_binary(ulp_pulse_counter_bin_start, size));

--- a/components/kernel/ulp/pulse_counter.c
+++ b/components/kernel/ulp/pulse_counter.c
@@ -1,13 +1,11 @@
 /**
  * ULP/LP-core pulse counter firmware.
  *
- * ESP32-S3 (ULP-RISC-V): halt-based execution driven by the ULP timer.
- *   The coprocessor runs once per timer tick, checks GPIOs, then calls ulp_riscv_halt().
- *   The timer period (set via ulp_set_wakeup_period) defines the polling interval.
- *   State survives across halt/restart cycles because start.S does not zero .bss.
- *
- * ESP32-C6 (LP Core): continuous execution driven by the HP CPU wakeup source.
- *   The LP Core runs an infinite polling loop with cycle-counting debounce.
+ * Both platforms run a continuous polling loop with cycle-counting debounce:
+ * - ESP32-S3 (ULP-RISC-V): ~17.5 MHz RTC fast clock.  Started once by the ULP timer;
+ *   runs continuously thereafter (never calls ulp_riscv_halt()).
+ * - ESP32-C6 (LP Core): ~16 MHz LP_FAST_CLK.  Started once by the HP CPU wakeup source;
+ *   runs continuously in an infinite loop.
  *
  * Configuration is written to RTC slow memory by the main CPU before starting the coprocessor.
  * Counts are read from RTC slow memory by the main CPU at any time (lock-free).
@@ -18,19 +16,27 @@
 #include <stdint.h>
 
 #ifdef CONFIG_ULP_COPROC_TYPE_LP_CORE
-// ESP32-C6 LP Core GPIO API.
-// LP_FAST_CLK RC oscillator is tuned to ~16 MHz by ESP-IDF (TRM nominal: 20 MHz).
+// ESP32-C6 LP Core: ~16 MHz LP_FAST_CLK RC oscillator (TRM nominal: 20 MHz).
 #include "ulp_lp_core_gpio.h"
 #include "ulp_lp_core_utils.h"
 #define gpio_input_enable(gpio)    ulp_lp_core_gpio_input_enable((lp_io_num_t)(gpio))
 #define gpio_get_level(gpio)       ulp_lp_core_gpio_get_level((lp_io_num_t)(gpio))
+#define CYCLES_PER_US 16u
+static inline uint32_t get_ccount(void) {
+    uint32_t ccount;
+    __asm__ __volatile__("csrr %0, mcycle" : "=r"(ccount));
+    return ccount;
+}
 #else
-// ESP32-S3 ULP-RISC-V GPIO API.
-// RTC fast clock RC oscillator runs at ~17.5 MHz (ULP_RISCV_CYCLES_PER_US = 17.5).
+// ESP32-S3 ULP-RISC-V: ~17.5 MHz RTC fast clock RC oscillator.
 #include "ulp_riscv_gpio.h"
 #include "ulp_riscv_utils.h"
 #define gpio_input_enable(gpio)    ulp_riscv_gpio_input_enable(gpio)
 #define gpio_get_level(gpio)       ulp_riscv_gpio_get_level(gpio)
+#define CYCLES_PER_US 17u
+static inline uint32_t get_ccount(void) {
+    return ulp_riscv_get_cpu_cycles();
+}
 #endif
 
 #define MAX_CHANNELS 4
@@ -53,9 +59,7 @@ volatile uint32_t running;
 
 /**
  * Debounce window in microseconds. Written by main CPU before coprocessor starts.
- *
- * ESP32-S3: converted to restart-period counts on first run (timer period = 1000 µs).
- * ESP32-C6: converted to LP Core CPU cycles on first run.
+ * Converted to coprocessor CPU cycles during init on both platforms.
  */
 volatile uint32_t debounce_us[MAX_CHANNELS];
 
@@ -68,24 +72,9 @@ volatile uint32_t pulse_count[MAX_CHANNELS];
 
 // ---------------------------------------------------------------------------
 
-#ifdef CONFIG_ULP_COPROC_TYPE_LP_CORE
-
-// ---------------------------------------------------------------------------
-// ESP32-C6 LP Core: continuous execution, cycle-counting debounce
-// ---------------------------------------------------------------------------
-
-static inline uint32_t get_ccount(void) {
-    uint32_t ccount;
-    __asm__ __volatile__("csrr %0, mcycle" : "=r"(ccount));
-    return ccount;
-}
-
-// These only need to survive within the single continuous run, so .bss is fine.
 static uint32_t last_level[MAX_CHANNELS];
 static uint32_t last_edge_cycle[MAX_CHANNELS];
 static uint32_t debounce_cycles[MAX_CHANNELS];
-
-#define DEBOUNCE_CYCLES(us) ((us) * 16u)
 
 int main(void) {
     running = 1;
@@ -95,8 +84,7 @@ int main(void) {
         gpio_input_enable(gpio_num[i]);
         last_level[i]      = gpio_get_level(gpio_num[i]);
         last_edge_cycle[i] = get_ccount();
-        // Convert debounce time from microseconds to coprocessor CPU cycles.
-        debounce_cycles[i] = DEBOUNCE_CYCLES(debounce_us[i]);
+        debounce_cycles[i] = debounce_us[i] * CYCLES_PER_US;
     }
 
     while (1) {
@@ -122,59 +110,3 @@ int main(void) {
 
     return 0;
 }
-
-#else
-
-// ---------------------------------------------------------------------------
-// ESP32-S3 ULP-RISC-V: halt-based execution, period-counting debounce
-//
-// start.S does not zero .bss on restart, so all variables survive halt/restart cycles.
-//
-// last_level: must start as SENTINEL (UINT32_MAX, not 0) after ulp_riscv_load_binary(),
-//   so it carries a non-zero initialiser to force placement in .data. On first run we
-//   read the actual GPIO level and seed the state; subsequent runs detect edges.
-//
-// Timer period is set to 1000 µs in PulseCounter.cpp (ulp_set_wakeup_period).
-// ---------------------------------------------------------------------------
-
-#define ULP_TIMER_PERIOD_US 1000u
-
-#define SENTINEL UINT32_MAX
-
-static uint32_t last_level[MAX_CHANNELS] = {SENTINEL, SENTINEL, SENTINEL, SENTINEL};
-static uint32_t debounce_count[MAX_CHANNELS];
-
-int main(void) {
-    running = 1;
-    uint32_t n = channel_count;
-
-    for (uint32_t i = 0; i < n; i++) {
-        if (last_level[i] == SENTINEL) {
-            // First run for this channel: configure GPIO and seed state.
-            gpio_input_enable(gpio_num[i]);
-            last_level[i]    = gpio_get_level(gpio_num[i]);
-            debounce_count[i] = 0;
-            continue;
-        }
-
-        // Advance debounce countdown.
-        if (debounce_count[i] > 0) {
-            debounce_count[i]--;
-        }
-
-        uint32_t level = gpio_get_level(gpio_num[i]);
-        if (level != last_level[i]) {
-            last_level[i] = level;
-            if (level == 0 && debounce_count[i] == 0) {
-                // Falling edge outside debounce window: count and arm debounce.
-                pulse_count[i]++;
-                debounce_count[i] = debounce_us[i] / ULP_TIMER_PERIOD_US;
-            }
-        }
-    }
-
-    ulp_riscv_halt();
-    return 0;
-}
-
-#endif

--- a/components/kernel/ulp/pulse_counter.c
+++ b/components/kernel/ulp/pulse_counter.c
@@ -80,28 +80,28 @@ int main(void) {
     running = 1;
     uint32_t n = channel_count;
 
-    for (uint32_t i = 0; i < n; i++) {
-        gpio_input_enable(gpio_num[i]);
-        last_level[i]      = gpio_get_level(gpio_num[i]);
-        last_edge_cycle[i] = get_ccount();
-        debounce_cycles[i] = debounce_us[i] * CYCLES_PER_US;
+    for (uint32_t gpio_idx = 0; gpio_idx < n; gpio_idx++) {
+        gpio_input_enable(gpio_num[gpio_idx]);
+        last_level[gpio_idx]      = gpio_get_level(gpio_num[gpio_idx]);
+        last_edge_cycle[gpio_idx] = get_ccount();
+        debounce_cycles[gpio_idx] = debounce_us[gpio_idx] * CYCLES_PER_US;
     }
 
     while (1) {
         uint32_t now = get_ccount();
 
-        for (uint32_t i = 0; i < n; i++) {
-            uint32_t level = gpio_get_level(gpio_num[i]);
+        for (uint32_t gpio_idx = 0; gpio_idx < n; gpio_idx++) {
+            uint32_t level = gpio_get_level(gpio_num[gpio_idx]);
 
-            if (level != last_level[i]) {
-                last_level[i] = level;
+            if (level != last_level[gpio_idx]) {
+                last_level[gpio_idx] = level;
 
                 if (level == 0) {
                     // Falling edge detected. Apply debounce.
-                    uint32_t elapsed = now - last_edge_cycle[i];
-                    if (elapsed >= debounce_cycles[i]) {
-                        pulse_count[i]++;
-                        last_edge_cycle[i] = now;
+                    uint32_t elapsed = now - last_edge_cycle[gpio_idx];
+                    if (elapsed >= debounce_cycles[gpio_idx]) {
+                        pulse_count[gpio_idx]++;
+                        last_edge_cycle[gpio_idx] = now;
                     }
                 }
             }

--- a/docs/ULP-PulseCounter.md
+++ b/docs/ULP-PulseCounter.md
@@ -22,9 +22,9 @@ entirely by the RTC/LP domain. It keeps running during light sleep (and deep sle
 - **ESP32-C6**: LP Core coprocessor, LP domain, ~16 MHz
 
 The design:
-- Coprocessor firmware polls configured GPIO pins, detecting falling edges on up to `MAX_CHANNELS`
-  channels and incrementing a per-channel counter in RTC/LP slow memory. On ESP32-C6 this is a
-  continuous tight loop; on ESP32-S3 the ULP halts after each pass and is restarted by a 1 ms timer.
+- Coprocessor firmware polls configured GPIO pins in a continuous tight loop, detecting falling
+  edges on up to `MAX_CHANNELS` channels and incrementing a per-channel counter in RTC/LP slow
+  memory. Both ESP32-S3 and ESP32-C6 use the same loop structure with cycle-counting debounce.
 - The main CPU wakes only for WiFi DTIM beacons (every 20 beacons ≈ 2 s) and reads the accumulated
   counts from RTC/LP memory at that point. No GPIO-triggered wakeups for pulse counting at all.
 
@@ -48,9 +48,9 @@ oscillator to ~16 MHz (`LP_CORE_CPU_FREQUENCY_HZ = 16000000` in ESP-IDF). At 16 
 - Polling loop throughput: well above Nyquist for 1000 Hz signals.
 - 1 ms debounce window = 16 000 cycles at nominal frequency.
 
-The debounce conversion happens in the coprocessor firmware during init. On ESP32-C6, the firmware
-converts `debounce_us` to LP Core CPU cycles using `DEBOUNCE_CYCLES(us) = us * 16` (16 cycles/μs).
-On ESP32-S3, debounce is based on timer period counts (see [Debounce](#debounce) below).
+The debounce conversion happens in the coprocessor firmware during init. Both platforms convert
+`debounce_us` to CPU cycles: ESP32-C6 uses `us * 16` (16 cycles/μs at ~16 MHz) and ESP32-S3
+uses `us * 17` (17 cycles/μs at ~17.5 MHz).
 
 ## Concurrency
 
@@ -76,30 +76,14 @@ as long as the readout interval is much shorter than the overflow period — whi
 ## Debounce
 
 The main CPU passes a debounce time in microseconds (`ulp_debounce_us`); the coprocessor converts it
-to a platform-specific unit during its init phase. After counting a falling edge, subsequent edges are
-ignored until the debounce window has elapsed.
-
-### ESP32-C6
-
-Debounce uses the RISC-V `mcycle` counter (ticks at the LP Core CPU clock). The firmware converts
-microseconds to cycles during init:
+to CPU cycles during its init phase using the platform's clock rate. After counting a falling edge,
+subsequent edges are ignored until the debounce window has elapsed.
 
 ```
-debounce_cycles = debounce_us * 16    // 16 MHz LP Core clock
+debounce_cycles = debounce_us * CYCLES_PER_US
 ```
 
-### ESP32-S3
-
-Debounce counts ULP timer wakeup periods. The ULP halts after each polling pass and the timer restarts
-it every `ULP_TIMER_PERIOD_US` (1000 µs). The firmware converts microseconds to period counts:
-
-```
-debounce_count = debounce_us / ULP_TIMER_PERIOD_US    // e.g. 1000 µs → 1 period
-```
-
-Each wakeup decrements the counter; edges are ignored while the counter is non-zero.
-
-### Accuracy
+Where `CYCLES_PER_US` is 16 (ESP32-C6, ~16 MHz) or 17 (ESP32-S3, ~17.5 MHz).
 
 The RC oscillators are not trimmed to better than ~10%, but for a Hall-effect sensor — which produces
 clean, bounce-free transitions — this is entirely sufficient.
@@ -126,17 +110,25 @@ explicitly after all channels are registered. It zeroes the RTC/LP memory counte
 carrying over stale values from previous runs), writes the channel configuration, loads the
 coprocessor binary, and starts it.
 
+On both platforms the coprocessor runs a continuous polling loop that never returns from `main()`.
+
 ### ESP32-S3 startup
 
 ```cpp
+ulp_riscv_timer_stop();               // stop timer surviving from a previous boot
+ulp_riscv_reset();                     // clear any stale trap/done state
 ulp_riscv_load_binary(bin_start, size);
-ulp_set_wakeup_period(0, 1000);  // 1000 µs = ULP_TIMER_PERIOD_US
+ulp_set_wakeup_period(0, 1000);
 ulp_riscv_run();
 ```
 
-The ULP executes in a halt-based cycle: it polls all GPIOs once, then calls `ulp_riscv_halt()`.
-The ULP timer restarts it every 1000 µs. State survives across halt/restart cycles because
-ESP-IDF's `start.S` does not zero `.bss`.
+The RTC domain survives software resets, so the ULP timer from a previous boot may still be
+running. If it fires while `load_binary()` is zeroing RTC memory, the ULP executes illegal
+instructions and traps. `ulp_riscv_timer_stop()` + `ulp_riscv_reset()` prevent this.
+
+The ULP timer triggers the first start. Once running, `start.S` calls
+`ulp_riscv_rescue_from_monitor()` which clears `DONE` and `SHUT_RESET_EN`, so subsequent
+timer ticks are harmlessly ignored. The ULP then enters a continuous polling loop.
 
 ### ESP32-C6 startup
 


### PR DESCRIPTION
We now use the same infinite loop on both platforms instead of a halt+restart on ESP32-S3.